### PR TITLE
fix(web-ui): Prevent analyze request with empty plugin name

### DIFF
--- a/web-ui/src/App.tdd.test.tsx
+++ b/web-ui/src/App.tdd.test.tsx
@@ -181,4 +181,28 @@ describe("App - TDD: Upload requires plugin selection", () => {
     const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
     expect(fileInput).not.toBeDisabled();
   });
+
+  it("should not call analyzeImage if no plugin is selected", async () => {
+    const { apiClient } = await import("./api/client");
+    const mockAnalyze = vi.mocked(apiClient.analyzeImage);
+    mockAnalyze.mockClear();
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Switch to upload view
+    const uploadTab = screen.getByRole("button", { name: /upload/i });
+    await user.click(uploadTab);
+
+    // Force-enable the input to simulate edge case (e.g., race condition)
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fileInput.disabled = false;
+
+    // Upload a file without selecting a plugin
+    const file = new File(["test"], "test.png", { type: "image/png" });
+    await user.upload(fileInput, file);
+
+    // analyzeImage should NOT have been called
+    expect(mockAnalyze).not.toHaveBeenCalled();
+  });
 });

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -106,6 +106,7 @@ function App() {
     async (event: React.ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
       if (!file) return;
+      if (!selectedPlugin) return;
 
       setIsUploading(true);
       try {


### PR DESCRIPTION
## Summary

Add guard in `handleFileUpload` to prevent API calls when no plugin is selected.

## Changes

- `web-ui/src/App.tsx`: Add early return if `selectedPlugin` is empty
- `web-ui/src/App.tdd.test.tsx`: Add TDD test verifying `analyzeImage` is not called

## Testing

- All tests pass
- Lint clean
- Type check clean

Closes #56