### PR TITLE
fix(web-ui): Auto-select first plugin when none selected

### DIFF
--- a/web-ui/src/components/PluginSelector.test.tsx
+++ b/web-ui/src/components/PluginSelector.test.tsx
@@ -544,4 +544,23 @@ describe("PluginSelector", () => {
       expect(mockOnChange).toHaveBeenLastCalledWith("object_detection");
     });
   });
+
+  describe("Auto-selection when no plugin selected", () => {
+    it("should auto-select first plugin when selectedPlugin is empty string", async () => {
+      const mockOnChange = vi.fn();
+      mockGetPlugins.mockResolvedValue(mockPlugins);
+
+      render(
+        <PluginSelector
+          selectedPlugin=""
+          onPluginChange={mockOnChange}
+          disabled={false}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith("motion_detector");
+      });
+    });
+  });
 });

--- a/web-ui/src/components/PluginSelector.tsx
+++ b/web-ui/src/components/PluginSelector.tsx
@@ -194,9 +194,9 @@ export function PluginSelector({
 
     const pluginExists = plugins.some((p) => p.name === selectedPlugin);
 
-    if (!pluginExists && selectedPlugin) {
-      // Parent's selectedPlugin doesn't exist in loaded plugins
-      // Update parent to use the first available plugin
+    if (!selectedPlugin || !pluginExists) {
+      // No plugin selected or selected plugin doesn't exist
+      // Auto-select the first available plugin
       console.warn(
         `[PluginSelector] Selected plugin "${selectedPlugin}" not found. ` +
           `Defaulting to "${plugins[0].name}".`


### PR DESCRIPTION
## Summary

PluginSelector now auto-selects the first available plugin when `selectedPlugin` is empty string.

## Root Cause

The condition `if (!pluginExists && selectedPlugin)` only triggered when `selectedPlugin` had a value but didn't exist. When `selectedPlugin` was `""` (empty), no auto-selection occurred.

## Changes

- `PluginSelector.tsx`: Changed condition to `if (!selectedPlugin || !pluginExists)`
- `PluginSelector.test.tsx`: Added TDD test for empty string auto-selection

## Testing

- All 24 PluginSelector tests pass
- Lint clean
- Type check clean

Closes #56