### PR TITLE
fix(api): Add required plugin parameter to analyze endpoint tests

### DIFF
--- a/server/tests/api/test_api_endpoints.py
+++ b/server/tests/api/test_api_endpoints.py
@@ -218,7 +218,7 @@ class TestAnalyzeEndpointInputValidation:
         response = client.post(
             "/v1/analyze",
             data=b"fake_image",
-            params={"options": "not valid json"},
+            params={"plugin": "ocr", "options": "not valid json"},
             headers={"X-API-Key": "test-user-key"},
         )
         # Should reject invalid JSON
@@ -229,6 +229,7 @@ class TestAnalyzeEndpointInputValidation:
         response = client.post(
             "/v1/analyze",
             content=b"not_valid_base64!!!",
+            params={"plugin": "ocr"},
             headers={"X-API-Key": "test-user-key"},
         )
         assert response.status_code == 400
@@ -237,6 +238,7 @@ class TestAnalyzeEndpointInputValidation:
         """Test analyze without image data fails."""
         response = client.post(
             "/v1/analyze",
+            params={"plugin": "ocr"},
             headers={"X-API-Key": "test-user-key"},
         )
         assert response.status_code == 400


### PR DESCRIPTION
## Summary

Fix 3 failing tests in CI workflow that were passing locally.

## Root Cause

Tests were missing the required `plugin` query parameter, causing Pydantic validation errors (422 Unprocessable Entity) instead of application logic errors (400 Bad Request).

## Changes

- Added `plugin="ocr"` parameter to three test cases:
  - test_analyze_invalid_json_options
  - test_analyze_invalid_base64_in_body  
  - test_analyze_empty_request_fails

## Testing

- All 695 tests pass
- Full pre-commit checks pass (black, ruff, mypy)
- Coverage: 87.55% (exceeds 80% requirement)