### PR TITLE
feat: Implement BasePlugin abstract class for #116

### DIFF
--- a/server/app/plugins/base.py
+++ b/server/app/plugins/base.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict
+
+
+class BasePlugin(ABC):
+    """
+    Canonical plugin contract for all ForgeSyte plugins.
+
+    Every plugin MUST:
+    - Subclass BasePlugin
+    - Define `name` (unique plugin identifier)
+    - Define `tools` (mapping of tool_name → callable)
+    - Implement `run_tool(tool_name, args)`
+    - Optionally implement `validate()` for startup checks
+    """
+
+    # Required plugin identifier
+    name: str
+
+    # Mapping of tool_name → callable
+    tools: Dict[str, Callable[..., Any]]
+
+    def __init__(self) -> None:
+        # Validate plugin structure immediately on instantiation
+        self._validate_plugin_contract()
+
+    # ----------------------------------------------------------------------
+    # Contract enforcement
+    # ----------------------------------------------------------------------
+
+    def _validate_plugin_contract(self) -> None:
+        """
+        Validate plugin structure at load time.
+        Raises explicit errors if plugin is malformed.
+        """
+
+        if not hasattr(self, "name") or not isinstance(self.name, str):
+            raise ValueError(
+                f"{self.__class__.__name__} must define a string attribute `name`"
+            )
+
+        if not hasattr(self, "tools") or not isinstance(self.tools, dict):
+            raise ValueError(
+                f"{self.__class__.__name__} must define a dict attribute `tools`"
+            )
+
+        for tool_name, handler in self.tools.items():
+            if not callable(handler):
+                raise ValueError(
+                    f"Tool '{tool_name}' in plugin '{self.name}' must be callable"
+                )
+
+    # ----------------------------------------------------------------------
+    # Required API
+    # ----------------------------------------------------------------------
+
+    @abstractmethod
+    def run_tool(self, tool_name: str, args: Dict[str, Any]) -> Any:
+        """
+        Execute a tool by name.
+
+        Must:
+        - Validate tool exists
+        - Validate args
+        - Execute tool handler
+        - Return JSON-serializable result
+        - Raise PluginExecutionError on failure
+        """
+        raise NotImplementedError
+
+    # ----------------------------------------------------------------------
+    # Optional lifecycle hook
+    # ----------------------------------------------------------------------
+
+    def validate(self) -> None:  # noqa: B027
+        """
+        Optional plugin-level validation hook.
+
+        Plugins may override this to:
+        - Load models
+        - Check file paths
+        - Check GPU availability
+        - Preload resources
+        - Validate configuration
+
+        Called once at plugin registration time.
+        """
+        pass

--- a/server/tests/plugins/test_base_plugin.py
+++ b/server/tests/plugins/test_base_plugin.py
@@ -1,0 +1,74 @@
+import pytest
+
+from app.plugins.base import BasePlugin
+
+
+def test_valid_plugin_loads():
+    class GoodPlugin(BasePlugin):
+        name = "good"
+
+        def __init__(self):
+            self.tools = {"echo": lambda x: x}
+            super().__init__()
+
+        def run_tool(self, tool_name, args):
+            return self.tools[tool_name](**args)
+
+    plugin = GoodPlugin()
+    assert plugin.name == "good"
+    assert callable(plugin.tools["echo"])
+
+
+def test_missing_name_raises():
+    class BadPlugin(BasePlugin):
+        def __init__(self):
+            self.tools = {}
+            super().__init__()
+
+        def run_tool(self, tool_name, args):
+            return None
+
+    with pytest.raises(ValueError):
+        BadPlugin()
+
+
+def test_missing_tools_raises():
+    class BadPlugin(BasePlugin):
+        name = "bad"
+
+        def __init__(self):
+            # tools missing
+            super().__init__()
+
+        def run_tool(self, tool_name, args):
+            return None
+
+    with pytest.raises(ValueError):
+        BadPlugin()
+
+
+def test_non_callable_tool_raises():
+    class BadPlugin(BasePlugin):
+        name = "bad"
+
+        def __init__(self):
+            self.tools = {"not_callable": 123}
+            super().__init__()
+
+        def run_tool(self, tool_name, args):
+            return None
+
+    with pytest.raises(ValueError):
+        BadPlugin()
+
+
+def test_run_tool_is_abstract():
+    class IncompletePlugin(BasePlugin):
+        name = "incomplete"
+
+        def __init__(self):
+            self.tools = {}
+            super().__init__()
+
+    with pytest.raises(TypeError):
+        IncompletePlugin()


### PR DESCRIPTION
Implements GitHub issue #116: Introduce BasePlugin Abstract Class

## Summary
This PR adds the canonical plugin contract for all ForgeSyte plugins.

## Changes

### New Files
- **server/app/plugins/base.py**: BasePlugin abstract class with:
  - Required attributes: , 
  - Required method: 
  - Contract validation in  checking name, tools, and callable tools
  - Optional  lifecycle hook

- **server/tests/plugins/test_base_plugin.py**: Unit tests covering:
  - Valid plugin loading
  - Missing  raises ValueError
  - Missing  raises ValueError
  - Non-callable tool raises ValueError
  - Abstract  enforcement

## Acceptance Criteria ✅
- [x] BasePlugin class implemented in server/app/plugins/base.py
- [x] Contract validation included
- [x] Unit tests verify valid plugin loads
- [x] Unit tests verify invalid plugin raises errors
- [x] No changes to loader (next issue)
- [x] No changes to plugin metadata

## Linked Issue
Closes #116