### PR TITLE
fix(#124): Fix /plugins endpoint crashing with TypeError

### DIFF
--- a/server/app/api.py
+++ b/server/app/api.py
@@ -353,7 +353,7 @@ async def list_plugins(
     logger.debug("Plugins listed", extra={"count": len(plugins)})
 
     return {
-        "plugins": [PluginMetadata(**meta) for meta in plugins],
+        "plugins": [plugin.metadata() for plugin in plugins],
         "count": len(plugins),
     }
 
@@ -375,15 +375,15 @@ async def get_plugin_info(
     Raises:
         HTTPException: 404 Not Found if plugin does not exist.
     """
-    plugin_info = await service.get_plugin_info(name)
-    if not plugin_info:
+    plugin = await service.get_plugin_info(name)
+    if not plugin:
         logger.warning("Plugin not found", extra={"plugin": name})
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Plugin '{name}' not found",
         )
 
-    return PluginMetadata(**plugin_info)
+    return plugin.metadata()
 
 
 @router.post("/plugins/{name}/reload")

--- a/server/app/services/plugin_management_service.py
+++ b/server/app/services/plugin_management_service.py
@@ -54,7 +54,7 @@ class PluginManagementService:
         self.registry = registry
         logger.debug("PluginManagementService initialized")
 
-    async def list_plugins(self) -> List[Dict[str, Any]]:
+    async def list_plugins(self) -> List[Any]:
         """List all available vision plugins with metadata.
 
         Retrieves metadata for all loaded plugins including:
@@ -64,7 +64,7 @@ class PluginManagementService:
         - Configuration options
 
         Returns:
-            List of plugin metadata dictionaries, each containing:
+            List of Plugin instances, each with a metadata() method to get:
                 - name: Plugin identifier
                 - version: Semantic version
                 - description: Human-readable description
@@ -89,7 +89,7 @@ class PluginManagementService:
             logger.exception("Failed to list plugins", extra={"error": str(e)})
             raise
 
-    async def get_plugin_info(self, name: str) -> Optional[Dict[str, Any]]:
+    async def get_plugin_info(self, name: str) -> Optional[Any]:
         """Get detailed information about a specific plugin.
 
         Retrieves comprehensive metadata for a single plugin:
@@ -102,8 +102,9 @@ class PluginManagementService:
             name: Plugin identifier
 
         Returns:
-            Plugin metadata dictionary if found, None if not found
-            Contains: name, version, description, capabilities, etc.
+            Plugin instance if found, None if not found.
+            Call plugin.metadata() to get PluginMetadata with details:
+                - name, version, description, capabilities, etc.
 
         Raises:
             RuntimeError: If plugin registry is unavailable
@@ -111,15 +112,8 @@ class PluginManagementService:
         try:
             plugin = self.registry.get(name)
             if plugin:
-                # Plugin may be a loaded instance with metadata() method
-                if hasattr(plugin, "metadata") and callable(plugin.metadata):
-                    metadata = plugin.metadata()
-                    logger.debug("Retrieved plugin info", extra={"plugin": name})
-                    return metadata  # type: ignore[return-value]
-                else:
-                    # Or may be a dict if from list()
-                    logger.debug("Retrieved plugin info", extra={"plugin": name})
-                    return plugin  # type: ignore[return-value]
+                logger.debug("Retrieved plugin info", extra={"plugin": name})
+                return plugin
             else:
                 logger.debug("Plugin not found", extra={"plugin": name})
                 return None


### PR DESCRIPTION
## Summary

Fix the architecture drift in plugin management - the  endpoint was crashing with a TypeError because it tried to unpack Plugin instances as dictionaries.

## Root Cause

When the plugin loader was refactored to use BasePlugin, it started returning Plugin **instances** instead of dicts. However, the API endpoints still tried to unpack them:

```python
PluginMetadata(**meta)  # meta is a Plugin instance
# TypeError: argument after ** must be a mapping, not Plugin
```

## The Fix (Mechanical & Clean)

The correct architecture is:
- `PluginRegistry.list()` returns List of Plugin instances  
- Plugin instances have a `.metadata()` method
- `.metadata()` returns a PluginMetadata Pydantic model  
- FastAPI automatically serializes Pydantic models

Simply **call the method** instead of trying to unpack:

### Before (Broken)
```python
# GET /plugins
return {"plugins": [PluginMetadata(**meta) for meta in plugins]}

# GET /plugins/{name}
return PluginMetadata(**plugin_info)
```

### After (Fixed)
```python
# GET /plugins
return {"plugins": [plugin.metadata() for plugin in plugins]}

# GET /plugins/{name}
return plugin.metadata()
```

## Changes

- **api.py**: 
  - GET /plugins now calls `plugin.metadata()` for each plugin
  - GET /plugins/{name} now returns `plugin.metadata()`

- **plugin_management_service.py**:
  - Updated return type annotations to reflect actual Plugin instances
  - Simplified `get_plugin_info()` logic (removed conditional checks)
  - Updated docstrings

## Testing

After this fix:
- ✅ GET /plugins returns 200 with list of plugins
- ✅ GET /plugins/{name} returns 200 with plugin metadata
- ✅ Web-UI can load plugins without 500 errors
- ✅ OCR, Moderation, YOLO plugins discoverable

## Checklist

- [x] All pre-commit hooks pass (black, ruff, mypy)
- [x] No test changes required
- [x] Architecture is now consistent
- [x] Fixes issue #124