### PR TITLE
fix: correct websocat binary URL and add diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq
 
-          WEBSOCAT_URL="https://github.com/vi/websocat/releases/latest/download/websocat_x86_64-linux-static"
+          # Corrected URL - using the static binary
+          WEBSOCAT_URL="https://github.com/vi/websocat/releases/latest/download/websocat.x86_64-unknown-linux-musl"
           WEBSOCAT_BIN="/usr/local/bin/websocat"
           WEBSOCAT_TMP="/tmp/websocat"
 
@@ -276,6 +277,9 @@ jobs:
           # Verify file is executable ELF binary (basic sanity check)
           if ! file "$WEBSOCAT_TMP" | grep -q "ELF"; then
             echo "::error::Downloaded websocat is not a valid ELF binary"
+            echo "File type: $(file "$WEBSOCAT_TMP")"
+            echo "File size: $(wc -c < "$WEBSOCAT_TMP") bytes"
+            echo "First 100 bytes: $(head -c 100 "$WEBSOCAT_TMP" | xxd)"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Fix websocat installer to use correct release binary name with enhanced diagnostics.

## Changes

- Update websocat URL to: websocat.x86_64-unknown-linux-musl (was: websocat_x86_64-linux-static)
- Add file type, size, and hex dump diagnostics on ELF validation failure
- Better debugging for download/binary issues

## Why

The old binary name doesn't exist in releases. The correct musl binary name is websocat.x86_64-unknown-linux-musl.

Diagnostics help troubleshoot download failures:
- File type verification
- Download size validation
- Binary header inspection

## Testing

- Lint: ✅ Pass
- Type check: ✅ Pass
- All quality checks: ✅ Pass

Closes #141