### PR TITLE
chore: Remove slow web-ui tests from pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,13 +28,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: web-ui-tests
-        name: Web-UI Tests
-        entry: bash -c 'if [ "$CI" != "true" ]; then echo "Skipping Playwright tests locally (CI=$CI). Set CI=true to run tests."; exit 0; fi && cd web-ui && npm install --silent && npm test -- --run'
-        language: system
-        pass_filenames: false
-        stages: [pre-commit]
-
       - id: validate-skipped-tests
         name: Validate skipped tests have APPROVED comments
         entry: bash


### PR DESCRIPTION
## Summary

Remove npm test execution from pre-commit hook to improve developer experience.

## Changes

- Remove web-ui-tests hook from .pre-commit-config.yaml
- Pre-commit now runs in <1s without npm dependency resolution
- Tests will run in dedicated CI workflow

## Testing

- Pre-commit passes all remaining hooks (black, ruff, mypy, eslint, validation)
- No test failures

## Checklist

- [x] Tests pass
- [x] Ruff lint clean
- [x] Mypy type check clean

Closes #81