### PR TITLE
fix(web-ui): Resolve Storybook version conflict

### DIFF
--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -23,8 +23,8 @@
   "devDependencies": {
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",
-    "@storybook/react": "^10.2.6",
-    "@storybook/react-vite": "^10.2.6",
+    "@storybook/react": "^8.6.14",
+    "@storybook/react-vite": "^8.6.14",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.1",


### PR DESCRIPTION
## Summary

Fix dependency conflict in Storybook packages to allow clean npm install.

## Changes

- Pin all Storybook packages to v8.6.14 (consistent versions)
- Removes need for --legacy-peer-deps workaround
- npm install now succeeds cleanly

## Testing

- npm install completes successfully
- No dependency conflicts

Closes #82