### PR TITLE
fix(#164): Correct tool_args key from 'image' to 'image_bytes'

### DIFF
--- a/server/app/mcp/handlers.py
+++ b/server/app/mcp/handlers.py
@@ -244,7 +244,7 @@ class MCPProtocolHandlers:
             if not tool_to_call:
                 tool_to_call = "default"
 
-            tool_args = {"image": image_bytes, "options": options or {}}
+            tool_args = {"image_bytes": image_bytes, "options": options or {}}
             if hasattr(plugin, "run_tool") and callable(plugin.run_tool):
                 maybe_coro = plugin.run_tool(tool_to_call, tool_args)
                 if inspect.isawaitable(maybe_coro):

--- a/server/app/services/vision_analysis.py
+++ b/server/app/services/vision_analysis.py
@@ -108,7 +108,8 @@ class VisionAnalysisService:
             # Use default tool if not specified
             tool_name = data.get("tool", "default")
             result = active_plugin.run_tool(
-                tool_name, {"image": image_bytes, "options": data.get("options", {})}
+                tool_name,
+                {"image_bytes": image_bytes, "options": data.get("options", {})},
             )
             processing_time = (time.time() - start_time) * 1000
 

--- a/server/app/tasks.py
+++ b/server/app/tasks.py
@@ -386,7 +386,7 @@ class TaskProcessor:
             # Use default tool if not specified
             tool_name = options.get("tool", "default")
             tool_args = {
-                "image": image_bytes,
+                "image_bytes": image_bytes,
                 "options": {k: v for k, v in options.items() if k != "tool"},
             }
             result = await loop.run_in_executor(

--- a/server/tests/execution/test_issue_164_tool_args_contract.py
+++ b/server/tests/execution/test_issue_164_tool_args_contract.py
@@ -1,0 +1,106 @@
+"""TEST-CHANGE: Test for Issue #164 — image_bytes key contract.
+
+Verifies that all code paths construct tool_args with the correct key name
+("image_bytes", not "image") when executing plugins.
+
+This test demonstrates the regression where multiple code paths were passing
+tool_args with the wrong key, causing plugins to fail with:
+    ValueError: image_bytes must be bytes
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestIssue164ToolArgsContract:
+    """Tests for Issue #164: All execution paths must use 'image_bytes' key."""
+
+    def test_tasks_py_uses_image_bytes_key(self):
+        """
+        Issue #164: tasks.py must use 'image_bytes' key in tool_args.
+        """
+        with open("/home/rogermt/forgesyte/server/app/tasks.py") as f:
+            content = f.read()
+
+        # Assert wrong key is NOT present
+        assert '"image": image_bytes' not in content, (
+            "tasks.py line 389: Found forbidden pattern '\"image\": image_bytes'. "
+            "Use '\"image_bytes\": image_bytes' instead."
+        )
+
+        # Assert correct key IS present in _process_job context
+        assert '"image_bytes": image_bytes' in content, (
+            "tasks.py: Expected '\"image_bytes\": image_bytes' in tool_args. "
+            "This is the required plugin contract key."
+        )
+
+    def test_vision_analysis_uses_image_bytes_key(self):
+        """
+        Issue #164: vision_analysis.py must use 'image_bytes' key in tool_args.
+        """
+        with open("/home/rogermt/forgesyte/server/app/services/vision_analysis.py") as f:
+            content = f.read()
+
+        # Assert wrong key is NOT present
+        assert '"image": image_bytes' not in content, (
+            "vision_analysis.py: Found forbidden pattern '\"image\": image_bytes'. "
+            "Use '\"image_bytes\": image_bytes' instead."
+        )
+
+        # Assert correct key IS present
+        assert '"image_bytes": image_bytes' in content, (
+            "vision_analysis.py: Expected '\"image_bytes\": image_bytes' in tool_args. "
+            "This is the required plugin contract key."
+        )
+
+    def test_mcp_handlers_uses_image_bytes_key(self):
+        """
+        Issue #164: mcp/handlers.py must use 'image_bytes' key in tool_args.
+        """
+        with open("/home/rogermt/forgesyte/server/app/mcp/handlers.py") as f:
+            content = f.read()
+
+        # Assert wrong key is NOT present
+        assert '"image": image_bytes' not in content, (
+            "mcp/handlers.py: Found forbidden pattern '\"image\": image_bytes'. "
+            "Use '\"image_bytes\": image_bytes' instead."
+        )
+
+        # Assert correct key IS present
+        assert '"image_bytes": image_bytes' in content, (
+            "mcp/handlers.py: Expected '\"image_bytes\": image_bytes' in tool_args. "
+            "This is the required plugin contract key."
+        )
+
+    def test_no_image_key_anywhere_in_pipeline(self):
+        """
+        Issue #164: Ensure no execution path uses bare 'image' key.
+
+        Scans all relevant execution modules to prevent regression.
+        """
+        files_to_check = [
+            "/home/rogermt/forgesyte/server/app/tasks.py",
+            "/home/rogermt/forgesyte/server/app/services/vision_analysis.py",
+            "/home/rogermt/forgesyte/server/app/mcp/handlers.py",
+            "/home/rogermt/forgesyte/server/app/services/analysis_service.py",
+        ]
+
+        for filepath in files_to_check:
+            try:
+                with open(filepath) as f:
+                    content = f.read()
+
+                # Forbidden patterns
+                forbidden = [
+                    '"image": image_bytes',
+                    "'image': image_bytes",
+                ]
+
+                for pattern in forbidden:
+                    assert pattern not in content, (
+                        f"{filepath}: Found forbidden key pattern '{pattern}'. "
+                        f"All plugins expect 'image_bytes', not 'image'."
+                    )
+            except FileNotFoundError:
+                pytest.skip(f"File not found: {filepath}")

--- a/server/tests/mcp/test_mcp_handlers_gemini_integration.py
+++ b/server/tests/mcp/test_mcp_handlers_gemini_integration.py
@@ -68,7 +68,7 @@ class MockPlugin:
     def run_tool(self, tool_name: str, args: dict) -> dict:
         """Execute a tool by name."""
         if tool_name == "default":
-            return self.analyze_image(args["image"], args.get("options", {}))
+            return self.analyze_image(args["image_bytes"], args.get("options", {}))
         raise ValueError(f"Unknown tool: {tool_name}")
 
     def on_unload(self) -> None:

--- a/server/tests/mcp/test_mcp_handlers_http_endpoint.py
+++ b/server/tests/mcp/test_mcp_handlers_http_endpoint.py
@@ -64,7 +64,7 @@ class MockPlugin:
     def run_tool(self, tool_name: str, args: dict) -> dict:
         """Execute a tool by name."""
         if tool_name == "default":
-            return self.analyze_image(args["image"], args.get("options", {}))
+            return self.analyze_image(args["image_bytes"], args.get("options", {}))
         raise ValueError(f"Unknown tool: {tool_name}")
 
     def on_unload(self) -> None:

--- a/server/tests/mcp/test_mcp_handlers_tools.py
+++ b/server/tests/mcp/test_mcp_handlers_tools.py
@@ -180,7 +180,7 @@ class TestToolsCallHandler:
                 def run_tool(self, tool_name, args):
                     if tool_name == "ocr":
                         return self.analyze_image(
-                            args["image"], args.get("options", {})
+                            args["image_bytes"], args.get("options", {})
                         )
                     raise ValueError(f"Unknown tool: {tool_name}")
 
@@ -242,7 +242,7 @@ class TestToolsCallHandler:
                 def run_tool(self, tool_name, args):
                     if tool_name == "ocr":
                         return self.analyze_image(
-                            args["image"], args.get("options", {})
+                            args["image_bytes"], args.get("options", {})
                         )
                     raise ValueError(f"Unknown tool: {tool_name}")
 
@@ -297,7 +297,7 @@ class TestToolsCallHandler:
                 def run_tool(self, tool_name, args):
                     if tool_name == "ocr":
                         return self.analyze_image(
-                            args["image"], args.get("options", {})
+                            args["image_bytes"], args.get("options", {})
                         )
                     raise ValueError(f"Unknown tool: {tool_name}")
 
@@ -404,7 +404,7 @@ class TestToolsCallHandler:
                 def run_tool(self, tool_name, args):
                     if tool_name == "ocr":
                         return self.analyze_image(
-                            args["image"], args.get("options", {})
+                            args["image_bytes"], args.get("options", {})
                         )
                     raise ValueError(f"Unknown tool: {tool_name}")
 
@@ -477,7 +477,7 @@ class TestToolsCallHandler:
                 def run_tool(self, tool_name, args):
                     if tool_name == "ocr":
                         return self.analyze_image(
-                            args["image"], args.get("options", {})
+                            args["image_bytes"], args.get("options", {})
                         )
                     raise ValueError(f"Unknown tool: {tool_name}")
 

--- a/server/tests/mcp/test_mcp_routes_content_length.py
+++ b/server/tests/mcp/test_mcp_routes_content_length.py
@@ -55,7 +55,7 @@ class TestContentLengthCorrectness:
                 def run_tool(self, tool_name, args):
                     if tool_name == "ocr":
                         return self.analyze_image(
-                            args["image"], args.get("options", {})
+                            args["image_bytes"], args.get("options", {})
                         )
                     raise ValueError(f"Unknown tool: {tool_name}")
 
@@ -127,7 +127,7 @@ class TestContentLengthCorrectness:
                 def run_tool(self, tool_name, args):
                     if tool_name == "ocr":
                         return self.analyze_image(
-                            args["image"], args.get("options", {})
+                            args["image_bytes"], args.get("options", {})
                         )
                     raise ValueError(f"Unknown tool: {tool_name}")
 
@@ -194,7 +194,9 @@ class TestContentLengthCorrectness:
 
             def run_tool(self, tool_name, args):
                 if tool_name == "ocr":
-                    return self.analyze_image(args["image"], args.get("options", {}))
+                    return self.analyze_image(
+                        args["image_bytes"], args.get("options", {})
+                    )
                 raise ValueError(f"Unknown tool: {tool_name}")
 
         pm = PluginRegistry()

--- a/server/tests/mcp/test_mcp_url_fetch.py
+++ b/server/tests/mcp/test_mcp_url_fetch.py
@@ -56,7 +56,7 @@ class TestToolsCallURLFetch:
                 def run_tool(self, tool_name, args):
                     if tool_name == "ocr":
                         return self.analyze_image(
-                            args["image"], args.get("options", {})
+                            args["image_bytes"], args.get("options", {})
                         )
                     raise ValueError(f"Unknown tool: {tool_name}")
 
@@ -241,7 +241,7 @@ class TestToolsCallURLFetch:
                 def run_tool(self, tool_name, args):
                     if tool_name == "ocr":
                         return self.analyze_image(
-                            args["image"], args.get("options", {})
+                            args["image_bytes"], args.get("options", {})
                         )
                     raise ValueError(f"Unknown tool: {tool_name}")
 
@@ -297,7 +297,7 @@ class TestToolsCallURLFetch:
                 def run_tool(self, tool_name, args):
                     if tool_name == "ocr":
                         return self.analyze_image(
-                            args["image"], args.get("options", {})
+                            args["image_bytes"], args.get("options", {})
                         )
                     raise ValueError(f"Unknown tool: {tool_name}")
 
@@ -353,7 +353,7 @@ class TestToolsCallURLFetch:
                 def run_tool(self, tool_name, args):
                     if tool_name == "ocr":
                         return self.analyze_image(
-                            args["image"], args.get("options", {})
+                            args["image_bytes"], args.get("options", {})
                         )
                     raise ValueError(f"Unknown tool: {tool_name}")
 


### PR DESCRIPTION
## Summary

Fixed Issue #164: Plugin contract violation where tool_args was using the wrong key.

All 3 execution paths (tasks.py, vision_analysis.py, mcp/handlers.py) were passing 'image' but plugins expect 'image_bytes'.

## Changes

- tasks.py line 389: Changed tool_args key to 'image_bytes'
- vision_analysis.py line 111: Changed tool_args key to 'image_bytes'  
- mcp/handlers.py line 247: Changed tool_args key to 'image_bytes'

## Tests Added

Added test_issue_164_tool_args_contract.py with 4 static code contract tests:
- test_tasks_py_uses_image_bytes_key
- test_vision_analysis_uses_image_bytes_key
- test_mcp_handlers_uses_image_bytes_key
- test_no_image_key_anywhere_in_pipeline

## Tests Updated

All MCP test files updated to use correct 'image_bytes' key:
- test_mcp_handlers_gemini_integration.py
- test_mcp_handlers_http_endpoint.py
- test_mcp_handlers_tools.py
- test_mcp_routes_content_length.py
- test_mcp_url_fetch.py

## Verification

✅ Pre-commit: black, ruff, mypy, tests all pass
✅ Execution governance: no violations
✅ Plugin tests: 122/122 pass
✅ Execution tests: 88/88 pass

Closes #164