### PR TITLE
fix(#164): Use relative paths in tests for CI compatibility

### DIFF
--- a/server/tests/execution/test_issue_164_tool_args_contract.py
+++ b/server/tests/execution/test_issue_164_tool_args_contract.py
@@ -8,7 +8,7 @@ tool_args with the wrong key, causing plugins to fail with:
     ValueError: image_bytes must be bytes
 """
 
-from unittest.mock import MagicMock, patch
+from pathlib import Path
 
 import pytest
 
@@ -16,11 +16,25 @@ import pytest
 class TestIssue164ToolArgsContract:
     """Tests for Issue #164: All execution paths must use 'image_bytes' key."""
 
+    @staticmethod
+    def _get_app_file(relative_path: str) -> Path:
+        """Get path to app file relative to tests directory.
+
+        Uses relative paths to ensure tests work in any environment:
+        - Local development
+        - CI/CD (GitHub Actions)
+        - Docker containers
+        - Any other execution context
+        """
+        test_dir = Path(__file__).parent.parent
+        return test_dir.parent / "app" / relative_path
+
     def test_tasks_py_uses_image_bytes_key(self):
         """
         Issue #164: tasks.py must use 'image_bytes' key in tool_args.
         """
-        with open("/home/rogermt/forgesyte/server/app/tasks.py") as f:
+        filepath = self._get_app_file("tasks.py")
+        with open(filepath) as f:
             content = f.read()
 
         # Assert wrong key is NOT present
@@ -39,7 +53,8 @@ class TestIssue164ToolArgsContract:
         """
         Issue #164: vision_analysis.py must use 'image_bytes' key in tool_args.
         """
-        with open("/home/rogermt/forgesyte/server/app/services/vision_analysis.py") as f:
+        filepath = self._get_app_file("services/vision_analysis.py")
+        with open(filepath) as f:
             content = f.read()
 
         # Assert wrong key is NOT present
@@ -58,7 +73,8 @@ class TestIssue164ToolArgsContract:
         """
         Issue #164: mcp/handlers.py must use 'image_bytes' key in tool_args.
         """
-        with open("/home/rogermt/forgesyte/server/app/mcp/handlers.py") as f:
+        filepath = self._get_app_file("mcp/handlers.py")
+        with open(filepath) as f:
             content = f.read()
 
         # Assert wrong key is NOT present
@@ -80,13 +96,14 @@ class TestIssue164ToolArgsContract:
         Scans all relevant execution modules to prevent regression.
         """
         files_to_check = [
-            "/home/rogermt/forgesyte/server/app/tasks.py",
-            "/home/rogermt/forgesyte/server/app/services/vision_analysis.py",
-            "/home/rogermt/forgesyte/server/app/mcp/handlers.py",
-            "/home/rogermt/forgesyte/server/app/services/analysis_service.py",
+            "tasks.py",
+            "services/vision_analysis.py",
+            "mcp/handlers.py",
+            "services/analysis_service.py",
         ]
 
-        for filepath in files_to_check:
+        for relative_path in files_to_check:
+            filepath = self._get_app_file(relative_path)
             try:
                 with open(filepath) as f:
                     content = f.read()


### PR DESCRIPTION
## Issue

Previous test implementation used hardcoded absolute paths that failed in CI/CD:
- FileNotFoundError: [Errno 2] No such file or directory: '/home/rogermt/forgesyte/server/app/tasks.py'

These paths work locally but fail in GitHub Actions, Docker, and remote systems.

## Solution

Replaced hardcoded absolute paths with relative Path(__file__).parent pattern.

### Pattern Applied

```python
# OLD (fails in CI)
with open('/home/rogermt/forgesyte/server/app/tasks.py') as f:

# NEW (works everywhere)
test_dir = Path(__file__).parent.parent
filepath = test_dir.parent / 'app' / 'tasks.py'
with open(filepath) as f:
```

## Codebase Scan Results

Comprehensive scan of entire codebase for similar issues:
- ✅ No hardcoded /home/rogermt paths in code
- ✅ No hardcoded /opt/ or /var/ paths in code  
- ✅ No hardcoded fixture paths (correctly uses Path(__file__).parent pattern)
- ✅ Environment variable handling is correct
- ✅ No shell/system assumptions

**Conclusion:** This was the ONLY hardcoded path issue in the codebase.

## Compatibility

Tests now work in all environments:
- ✅ Local development machines
- ✅ CI/CD pipelines (GitHub Actions)
- ✅ Docker containers
- ✅ Remote CI systems
- ✅ Any arbitrary filesystem layout

## Verification

- ✅ Pre-commit: black, ruff, mypy, tests all pass
- ✅ Execution governance: no violations
- ✅ Test execution: 4/4 tests pass with relative paths
- ✅ Codebase scan: no other path issues found

Closes #164