### PR TITLE
chore: Fix swrtiching plugin and toll not changing from previou tool

### DIFF
--- a/web-ui/src/App.tdd.test.tsx
+++ b/web-ui/src/App.tdd.test.tsx
@@ -1,13 +1,19 @@
 /**
- * TDD tests for tool routing fix (Issue: selectedTool not wired through WebSocket).
+ * TDD tests for tool routing + plugin-switch tool reset (Issue #181).
  *
- * Verifies sendFrame receives the selected tool in its extra payload.
+ * Verifies:
+ * 1) sendFrame receives the currently selected tool in its "extra" payload
+ * 2) changing tool updates the tool sent to sendFrame
+ * 3) changing plugin resets tool to the new plugin’s first tool (prevents ocr+radar)
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import App from "./App";
+
+// ---------------------------------------------------------------------------
+// Mocks (must be declared before importing App)
+// ---------------------------------------------------------------------------
 
 vi.mock("./components/CameraPreview", () => ({
   CameraPreview: (props: { enabled: boolean; onFrame: (data: string) => void }) => (
@@ -29,11 +35,20 @@ vi.mock("./components/PluginSelector", () => ({
     disabled: boolean;
   }) => (
     <div data-testid="plugin-selector">
+      <div data-testid="selected-plugin">{props.selectedPlugin}</div>
+
       <button
-        data-testid="select-plugin"
-        onClick={() => props.onPluginChange("forgesyte-yolo-tracker")}
+        data-testid="select-yolo"
+        onClick={() => props.onPluginChange("yolo-tracker")}
       >
-        Select Plugin
+        Select YOLO
+      </button>
+
+      <button
+        data-testid="select-ocr"
+        onClick={() => props.onPluginChange("ocr")}
+      >
+        Select OCR
       </button>
     </div>
   ),
@@ -41,18 +56,26 @@ vi.mock("./components/PluginSelector", () => ({
 
 vi.mock("./components/ToolSelector", () => ({
   ToolSelector: (props: {
-    pluginId: string;
+    pluginId: string | null;
     selectedTool: string;
     onToolChange: (t: string) => void;
     disabled: boolean;
   }) => (
     <div data-testid="tool-selector">
       <span data-testid="selected-tool">{props.selectedTool}</span>
+
       <button
         data-testid="select-ball-detection"
         onClick={() => props.onToolChange("ball_detection")}
       >
         Select Ball Detection
+      </button>
+
+      <button
+        data-testid="select-extract-text"
+        onClick={() => props.onToolChange("extract_text")}
+      >
+        Select Extract Text
       </button>
     </div>
   ),
@@ -74,16 +97,59 @@ vi.mock("./api/client", () => ({
   apiClient: {
     analyzeImage: vi.fn(),
     pollJob: vi.fn(),
-    getPluginManifest: vi.fn(() =>
-      Promise.resolve({
-        name: "forgesyte-yolo-tracker",
+    // IMPORTANT: return different manifests per plugin
+    getPluginManifest: vi.fn((pluginId: string) => {
+      if (pluginId === "yolo-tracker") {
+        return Promise.resolve({
+          id: "yolo-tracker",
+          name: "YOLO Tracker",
+          version: "1.0.0",
+          entrypoint: "plugin.py",
+          tools: {
+            // Object key order is insertion order: first tool becomes default
+            player_detection: {
+              inputs: {},
+              outputs: {},
+              description: "Detect players",
+            },
+            ball_detection: {
+              inputs: {},
+              outputs: {},
+              description: "Detect ball",
+            },
+            radar: {
+              inputs: {},
+              outputs: {},
+              description: "Radar overlay",
+            },
+          },
+        });
+      }
+
+      if (pluginId === "ocr") {
+        return Promise.resolve({
+          id: "ocr",
+          name: "OCR",
+          version: "1.0.0",
+          entrypoint: "plugin.py",
+          tools: {
+            extract_text: {
+              inputs: {},
+              outputs: {},
+              description: "Extract text",
+            },
+          },
+        });
+      }
+
+      return Promise.resolve({
+        id: pluginId,
+        name: pluginId,
         version: "1.0.0",
-        tools: {
-          player_detection: { description: "Detect players" },
-          ball_detection: { description: "Detect ball" },
-        },
-      })
-    ),
+        entrypoint: "plugin.py",
+        tools: {},
+      });
+    }),
   },
 }));
 
@@ -91,12 +157,19 @@ vi.mock("./hooks/useWebSocket", () => ({
   useWebSocket: vi.fn(),
 }));
 
+import App from "./App";
 import { useWebSocket } from "./hooks/useWebSocket";
 
 const mockUseWebSocket = vi.mocked(useWebSocket);
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 function setupHook(overrides: Record<string, unknown> = {}) {
   const mockSendFrame = vi.fn();
+  const mockSwitchPlugin = vi.fn();
+
   mockUseWebSocket.mockReturnValue({
     isConnected: true,
     isConnecting: false,
@@ -104,123 +177,123 @@ function setupHook(overrides: Record<string, unknown> = {}) {
     attempt: 0,
     error: null,
     errorInfo: null,
+
     sendFrame: mockSendFrame,
-    switchPlugin: vi.fn(),
+    switchPlugin: mockSwitchPlugin,
     disconnect: vi.fn(),
     reconnect: vi.fn(),
+
     latestResult: null,
     stats: { framesProcessed: 0, avgProcessingTime: 0 },
+
     ...overrides,
-  } as ReturnType<typeof useWebSocket>);
-  return { mockSendFrame };
+  } as unknown as ReturnType<typeof useWebSocket>);
+
+  return { mockSendFrame, mockSwitchPlugin };
 }
+
+async function startStreaming(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: /start streaming/i }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 describe("App - Tool Routing via sendFrame", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should pass selectedTool in sendFrame extra payload when streaming", async () => {
+  it("passes auto-selected first tool in sendFrame extra payload when streaming", async () => {
     const { mockSendFrame } = setupHook();
     const user = userEvent.setup();
 
-    await act(async () => {
-      render(<App />);
+    render(<App />);
+
+    // Select YOLO plugin -> manifest loads -> App auto-selects first tool (player_detection)
+    await user.click(screen.getByTestId("select-yolo"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-tool")).toHaveTextContent("player_detection");
     });
 
-    // Select a plugin (triggers manifest load → auto-selects first tool)
-    await user.click(screen.getByTestId("select-plugin"));
-
-    // Wait for manifest to load and auto-select first tool
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 50));
-    });
-
-    // Enable streaming
-    await user.click(screen.getByRole("button", { name: /start streaming/i }));
+    await startStreaming(user);
 
     // Emit a frame
     await user.click(screen.getByTestId("emit-frame"));
 
     expect(mockSendFrame).toHaveBeenCalledTimes(1);
+
     const [imageData, , extra] = mockSendFrame.mock.calls[0];
     expect(imageData).toBe("base64imagedata");
-    expect(extra).toBeDefined();
-    expect(extra).toHaveProperty("tool", "player_detection");
+    expect(extra).toEqual(expect.objectContaining({ tool: "player_detection" }));
   });
 
-  it("should pass updated tool when user switches tool", async () => {
+  it("passes updated tool when user switches tool", async () => {
     const { mockSendFrame } = setupHook();
     const user = userEvent.setup();
 
-    await act(async () => {
-      render(<App />);
-    });
+    render(<App />);
 
-    // Select plugin
-    await user.click(screen.getByTestId("select-plugin"));
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 50));
+    await user.click(screen.getByTestId("select-yolo"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-tool")).toHaveTextContent("player_detection");
     });
 
     // Switch tool to ball_detection
     await user.click(screen.getByTestId("select-ball-detection"));
 
-    // Enable streaming
-    await user.click(screen.getByRole("button", { name: /start streaming/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-tool")).toHaveTextContent("ball_detection");
+    });
 
-    // Emit a frame
+    await startStreaming(user);
+
+    await user.click(screen.getByTestId("emit-frame"));
+
+    expect(mockSendFrame).toHaveBeenCalledTimes(1);
+
+    const [, , extra] = mockSendFrame.mock.calls[0];
+    expect(extra).toEqual(expect.objectContaining({ tool: "ball_detection" }));
+  });
+
+  it("resets tool when plugin changes (yolo -> ocr) and uses new plugin default", async () => {
+    const { mockSendFrame, mockSwitchPlugin } = setupHook();
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    // Start on YOLO and choose a non-OCR tool
+    await user.click(screen.getByTestId("select-yolo"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-tool")).toHaveTextContent("player_detection");
+    });
+
+    await user.click(screen.getByTestId("select-ball-detection"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-tool")).toHaveTextContent("ball_detection");
+    });
+
+    // Switch plugin to OCR -> App should reset selectedTool -> auto-select OCR's first tool ("extract_text")
+    await user.click(screen.getByTestId("select-ocr"));
+
+    // When connected, App should also call switchPlugin on the websocket
+    expect(mockSwitchPlugin).toHaveBeenCalledWith("ocr");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-tool")).toHaveTextContent("extract_text");
+    });
+
+    // Start streaming and emit frame -> must use extract_text, not previous yolo tool
+    await startStreaming(user);
     await user.click(screen.getByTestId("emit-frame"));
 
     expect(mockSendFrame).toHaveBeenCalledTimes(1);
     const [, , extra] = mockSendFrame.mock.calls[0];
-    expect(extra).toHaveProperty("tool", "ball_detection");
-  });
-
-  it("TEST-CHANGE: should reset tool when plugin changes", async () => {
-    // This test verifies that the reset effect exists in App.tsx
-    // The effect: useEffect(() => { setSelectedTool(""); }, [selectedPlugin])
-    //
-    // Full integration test: When user switches from yolo-tracker to ocr plugin,
-    // the selectedTool is cleared, allowing auto-select to pick the first tool
-    // from the new plugin's manifest. This prevents "Unknown tool" errors.
-    //
-    // Since the mock plugin selector always selects "forgesyte-yolo-tracker",
-    // we can't test a real plugin switch in this unit test.
-    // However, the effect is verified to exist in App.tsx line 162-167.
-    //
-    // To test end-to-end, use: navigate to Web-UI, select yolo-tracker,
-    // switch tool to "radar", switch to "ocr" plugin, upload file.
-    // Expected: No "ValueError: Unknown tool: radar" error.
-
-    const user = userEvent.setup();
-
-    await act(async () => {
-      render(<App />);
-    });
-
-    // Select plugin to initialize
-    await user.click(screen.getByTestId("select-plugin"));
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 100));
-    });
-
-    // Switch to ball_detection tool
-    await user.click(screen.getByTestId("select-ball-detection"));
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 50));
-    });
-
-    // Verify tool is now ball_detection
-    const selectedToolElement = screen.getByTestId("selected-tool");
-    expect(selectedToolElement).toHaveTextContent("ball_detection");
-
-    // In a real scenario, clicking plugin selector would change selectedPlugin
-    // which would trigger the reset effect (setSelectedTool(""))
-    // Then auto-select would pick the first tool from new plugin
-    //
-    // This test documents the expected behavior:
-    // When selectedPlugin changes -> selectedTool resets -> auto-select fires
-    // Result: tool is reset to first tool of new plugin, preventing errors
+    expect(extra).toEqual(expect.objectContaining({ tool: "extract_text" }));
   });
 });


### PR DESCRIPTION
// web-ui/src/App.tsx

/**
 * Main application component for ForgeSyte
 *
 * Fixes included:
 * - Reset selectedTool whenever selectedPlugin changes (prevents sending old tool to new plugin)
 * - Auto-select first valid tool from the newly loaded manifest
 *
 * Notes:
 * - Assumes your Option 2 API change is live:
 *   POST /v1/analyze?plugin=...&tool=...
 * - Assumes apiClient.analyzeImage(file, plugin, tool) exists (as per your working fix)
 */

import React, { useCallback, useEffect, useMemo, useState } from "react";
import { CameraPreview } from "./components/CameraPreview";
import { PluginSelector } from "./components/PluginSelector";
import { ToolSelector } from "./components/ToolSelector";
import { JobList } from "./components/JobList";
import { ResultsPanel } from "./components/ResultsPanel";
import { VideoTracker } from "./components/VideoTracker";
import { useWebSocket, FrameResult } from "./hooks/useWebSocket";
import { apiClient, Job } from "./api/client";
import { detectToolType } from "./utils/detectToolType";
import type { PluginManifest } from "./types/plugin";

const WS_BACKEND_URL =
  import.meta.env.VITE_WS_BACKEND_URL || "ws://localhost:8000";

type ViewMode = "stream" | "upload" | "jobs";

function App() {
  const [viewMode, setViewMode] = useState<ViewMode>("stream");
  const [selectedPlugin, setSelectedPlugin] = useState<string>("");
  const [selectedTool, setSelectedTool] = useState<string>("");

  const [streamEnabled, setStreamEnabled] = useState(false);

  const [selectedJob, setSelectedJob] = useState<Job | null>(null);
  const [uploadResult, setUploadResult] = useState<Job | null>(null);
  const [isUploading, setIsUploading] = useState(false);

  const [manifest, setManifest] = useState<PluginManifest | null>(null);
  const [manifestError, setManifestError] = useState<string | null>(null);
  const [manifestLoading, setManifestLoading] = useState(false);

  // Compute tool list from manifest
  const toolList = useMemo(() => {
    if (!manifest) return [];
    return Object.keys(manifest.tools);
  }, [manifest]);

  const {
    isConnected,
    connectionStatus,
    attempt,
    error: wsError,
    sendFrame,
    switchPlugin,
    reconnect,
    latestResult,
  } = useWebSocket({
    url: `${WS_BACKEND_URL}/v1/stream`,
    plugin: selectedPlugin,
    onResult: (result: FrameResult) => {
      console.log("Frame result:", result);
    },
    onError: (error: string) => {
      console.error("WebSocket error:", error);
    },
    reconnectErrorDisplayDelayMs: 800,
  });

  // -------------------------------------------------------------------------
  // Load manifest when plugin changes
  // -------------------------------------------------------------------------
  useEffect(() => {
    if (!selectedPlugin) {
      setManifest(null);
      setManifestError(null);
      setManifestLoading(false);
      return;
    }

    let cancelled = false;

    async function loadManifest() {
      setManifestLoading(true);
      setManifestError(null);

      try {
        const manifestData = await apiClient.getPluginManifest(selectedPlugin);
        if (cancelled) return;

        setManifest(manifestData);
        setManifestError(null);
        console.log(
          "[App] Manifest loaded successfully for plugin:",
          selectedPlugin
        );
      } catch (err) {
        if (cancelled) return;

        const errorMessage =
          err instanceof Error ? err.message : "Unknown error loading manifest";
        console.error("Manifest load failed:", errorMessage);

        if (
          errorMessage.includes("<!DOCTYPE") ||
          errorMessage.includes("Unexpected token")
        ) {
          setManifestError(
            "Server returned HTML instead of JSON. Check that the server is running and the plugin exists."
          );
        } else {
          setManifestError(errorMessage);
        }

        setManifest(null);
      } finally {
        if (!cancelled) setManifestLoading(false);
      }
    }

    loadManifest();

    return () => {
      cancelled = true;
    };
  }, [selectedPlugin]);

  // -------------------------------------------------------------------------
  // FIX: Reset tool selection when plugin changes
  //
  // Prevents: plugin=ocr&tool=radar (radar was from yolo-tracker)
  // -------------------------------------------------------------------------
  useEffect(() => {
    setSelectedTool("");
    setUploadResult(null);
    setSelectedJob(null);
  }, [selectedPlugin]);

  // -------------------------------------------------------------------------
  // Ensure we always have a valid tool for the current manifest
  // - If none selected, select first
  // - If selected tool doesn't exist in this plugin, select first
  // -------------------------------------------------------------------------
  useEffect(() => {
    if (!manifest) return;

    if (toolList.length === 0) {
      setSelectedTool("");
      return;
    }

    if (!selectedTool || !toolList.includes(selectedTool)) {
      setSelectedTool(toolList[0]);
    }
  }, [manifest, toolList, selectedTool]);

  const statusText = useMemo(() => {
    switch (connectionStatus) {
      case "connected":
        return "Connected";
      case "connecting":
        return "Connecting...";
      case "reconnecting":
        return attempt > 0
          ? `Reconnecting... (attempt ${attempt})`
          : "Reconnecting...";
      case "failed":
        return "Connection failed";
      case "disconnected":
        return "Disconnected";
      default:
        return "Disconnected";
    }
  }, [connectionStatus, attempt]);

  const indicatorColor = useMemo(() => {
    switch (connectionStatus) {
      case "connected":
        return "#28a745";
      case "connecting":
        return "#ffc107";
      case "reconnecting":
        return "#fd7e14";
      case "failed":
        return "#dc3545";
      case "disconnected":
        return "#dc3545";
      default:
        return "#dc3545";
    }
  }, [connectionStatus]);

  const handleFrame = useCallback(
    (imageData: string) => {
      if (isConnected && streamEnabled) {
        // Tool is carried in the WS payload so server can route to correct tool
        sendFrame(imageData, undefined, { tool: selectedTool });
      }
    },
    [isConnected, streamEnabled, sendFrame, selectedTool]
  );

  const handlePluginChange = useCallback(
    (pluginName: string) => {
      setSelectedPlugin(pluginName);

      // If already connected, tell WS server to switch plugin too
      if (isConnected) {
        switchPlugin(pluginName);
      }
    },
    [isConnected, switchPlugin]
  );

  const handleToolChange = useCallback((toolName: string) => {
    setSelectedTool(toolName);
  }, []);

  const handleFileUpload = useCallback(
    async (event: React.ChangeEvent<HTMLInputElement>) => {
      const file = event.target.files?.[0];
      if (!file) return;
      if (!selectedPlugin) return;
      if (!selectedTool) return;

      setIsUploading(true);
      try {
        // Option 2 fix: backend accepts tool as a first-class query parameter
        const response = await apiClient.analyzeImage(
          file,
          selectedPlugin,
          selectedTool
        );
        const job = await apiClient.pollJob(response.job_id);
        setUploadResult(job);
        setSelectedJob(job);
      } catch (err) {
        console.error("Upload failed:", err);
      } finally {
        setIsUploading(false);
      }
    },
    [selectedPlugin, selectedTool]
  );

  const styles: Record<string, React.CSSProperties> = {
    app: {
      minHeight: "100vh",
      display: "flex",
      flexDirection: "column",
      backgroundColor: "var(--bg-primary)",
    },
    header: {
      padding: "16px 24px",
      backgroundColor: "var(--bg-primary)",
      borderBottom: "1px solid var(--border-color)",
      display: "flex",
      justifyContent: "space-between",
      alignItems: "center",
    },
    logo: {
      fontSize: "20px",
      fontWeight: 700,
      color: "var(--text-primary)",
    },
    nav: {
      display: "flex",
      gap: "8px",
    },
    navButton: {
      padding: "8px 16px",
      border: "1px solid transparent",
      borderRadius: "4px",
      cursor: "pointer",
      fontSize: "14px",
      transition: "all 0.2s",
      color: "var(--text-primary)",
      fontWeight: 500,
    },
    status: {
      display: "flex",
      alignItems: "center",
      gap: "12px",
      fontSize: "13px",
      color: "var(--text-secondary)",
    },
    indicator: {
      width: "8px",
      height: "8px",
      borderRadius: "50%",
    },
    main: {
      flex: 1,
      display: "grid",
      gridTemplateColumns: "300px 1fr 350px",
      gap: "16px",
      padding: "16px",
    },
    sidebar: {
      display: "flex",
      flexDirection: "column",
      gap: "16px",
    },
    panel: {
      backgroundColor: "var(--bg-secondary)",
      borderRadius: "8px",
      padding: "16px",
      border: "1px solid var(--border-light)",
    },
    content: {
      display: "flex",
      flexDirection: "column",
      gap: "16px",
    },
    errorBox: {
      padding: "12px",
      backgroundColor: "rgba(220, 53, 69, 0.1)",
      border: "1px solid var(--accent-red)",
      borderRadius: "4px",
      color: "var(--accent-red)",
      whiteSpace: "pre-wrap",
    },
  };

  return (
    <div style={styles.app}>
      <header style={styles.header}>
        <div style={styles.logo} data-testid="app-logo">
          🔧 ForgeSyte
        </div>

        <nav style={styles.nav}>
          {(["stream", "upload", "jobs"] as ViewMode[]).map((mode) => (
            <button
              key={mode}
              style={{
                ...styles.navButton,
                backgroundColor:
                  viewMode === mode
                    ? "var(--accent-orange)"
                    : "var(--bg-tertiary)",
                borderColor:
                  viewMode === mode
                    ? "var(--accent-orange)"
                    : "var(--border-light)",
              }}
              onClick={() => setViewMode(mode)}
            >
              {mode.charAt(0).toUpperCase() + mode.slice(1)}
            </button>
          ))}
        </nav>

        <div style={styles.status}>
          <div
            data-testid="connection-status-indicator"
            style={{
              ...styles.indicator,
              backgroundColor: indicatorColor,
            }}
          />
          <span data-testid="connection-status-text">{statusText}</span>
        </div>
      </header>

      <main style={styles.main}>
        <aside style={styles.sidebar}>
          <div style={styles.panel}>
            <PluginSelector
              selectedPlugin={selectedPlugin}
              onPluginChange={handlePluginChange}
              disabled={streamEnabled}
            />
          </div>

          <div style={styles.panel}>
            <ToolSelector
              pluginId={selectedPlugin}
              selectedTool={selectedTool}
              onToolChange={handleToolChange}
              disabled={streamEnabled}
            />
          </div>

          {viewMode === "jobs" && (
            <div style={styles.panel}>
              <JobList onJobSelect={setSelectedJob} />
            </div>
          )}
        </aside>

        <section style={styles.content}>
          {viewMode === "stream" && (
            <div style={styles.panel}>
              <div
                style={{
                  display: "flex",
                  justifyContent: "space-between",
                  alignItems: "center",
                  marginBottom: "12px",
                }}
              >
                <h3 style={{ margin: 0 }}>Stream</h3>

                <button
                  onClick={() => setStreamEnabled((v) => !v)}
                  disabled={!isConnected}
                  style={{
                    padding: "8px 16px",
                    backgroundColor: streamEnabled
                      ? "var(--accent-green)"
                      : "var(--bg-tertiary)",
                    color: "var(--text-primary)",
                    border: "1px solid var(--border-light)",
                    borderRadius: "4px",
                    cursor: isConnected ? "pointer" : "not-allowed",
                    fontWeight: 500,
                    fontSize: "13px",
                    transition: "all 0.2s",
                    opacity: isConnected ? 1 : 0.6,
                  }}
                >
                  {streamEnabled ? "Stop Streaming" : "Start Streaming"}
                </button>
              </div>

              <CameraPreview
                onFrame={handleFrame}
                enabled={streamEnabled}
                captureInterval={200}
              />
            </div>
          )}

          {viewMode === "upload" && manifest && selectedTool && (
            <>
              {detectToolType(manifest, selectedTool) === "frame" ? (
                <VideoTracker pluginId={selectedPlugin} toolName={selectedTool} />
              ) : (
                <div style={styles.panel}>
                  <p>Upload image for analysis</p>
                  <input
                    type="file"
                    accept="image/*"
                    onChange={handleFileUpload}
                    disabled={isUploading || !selectedPlugin || !selectedTool}
                  />
                  {isUploading && <p>Analyzing...</p>}
                </div>
              )}
            </>
          )}

          {viewMode === "upload" && (!manifest || !selectedTool) && (
            <div style={styles.panel}>
              {!selectedPlugin ? (
                <p>Select a plugin first</p>
              ) : manifestError ? (
                <div style={styles.errorBox}>
                  <strong>Manifest Error:</strong>
                  <br />
                  {manifestError}
                  <br />
                  <br />
                  <small>Check that the plugin is loaded and the server is running.</small>
                </div>
              ) : manifestLoading ? (
                <p>Loading manifest...</p>
              ) : !manifest ? (
                <p>Manifest not available</p>
              ) : !selectedTool ? (
                <p>Select a tool</p>
              ) : null}
            </div>
          )}

          {viewMode === "jobs" && (
            <div style={{ ...styles.panel, flex: 1 }}>
              <h3>Job Details</h3>
              {selectedJob ? (
                <pre>{JSON.stringify(selectedJob, null, 2)}</pre>
              ) : (
                <p>Select a job</p>
              )}
            </div>
          )}

          {wsError && (
            <div style={styles.errorBox} data-testid="ws-error-box">
              WebSocket Error: {wsError}
              {(connectionStatus === "failed" ||
                connectionStatus === "disconnected") && (
                <div style={{ marginTop: 12 }}>
                  <button
                    onClick={reconnect}
                    style={{
                      padding: "6px 12px",
                      borderRadius: 4,
                      border: "1px solid var(--border-light)",
                      backgroundColor: "var(--bg-tertiary)",
                      cursor: "pointer",
                      color: "var(--text-primary)",
                      fontWeight: 600,
                    }}
                  >
                    Reconnect
                  </button>
                </div>
              )}
            </div>
          )}
        </section>

        <aside>
          <ResultsPanel
            mode={viewMode === "stream" ? "stream" : "job"}
            streamResult={latestResult}
            job={viewMode === "upload" ? uploadResult : selectedJob}
          />
        </aside>
      </main>
    </div>
  );
}

export default App;
## Summary

Brief description of what this PR does.

---

## ✅ Phase 11 Stability Requirements (MANDATORY)

### Server Tests
**Must run before submitting:**
```bash
cd server && uv run pytest -v
```

- [ ] All server tests pass locally
- [ ] No regressions from Phase 9/10
- [ ] NEW tests added (if applicable)

### Plugin Execution Safety
**Does this touch plugin execution?**

If YES:
- [ ] All plugin calls use `run_plugin_sandboxed()`
- [ ] No direct `plugin.run()` calls
- [ ] `PluginRegistry.mark_failed()` on errors
- [ ] `PluginRegistry.record_success()` on success

### Plugin Registry State
**Is plugin state being updated?**

If YES:
- [ ] `registry.register()` for new plugins
- [ ] `registry.mark_failed()` for failures
- [ ] `registry.mark_unavailable()` for missing deps
- [ ] Success/error counts tracked

### Health API (If applicable)
**Does this touch health endpoints?**

If YES:
- [ ] `/v1/plugins` returns correct state
- [ ] `/v1/plugins/{name}/health` returns correct state
- [ ] Endpoints never return 500
- [ ] Tests verify 200 and 404 only

### Error Messages
**Are error messages clear?**

Test format:
```json
{
  "state": "FAILED",
  "reason": "ImportError: No module named 'torch' (install with: pip install torch)"
}
```

NOT generic "Error".

- [ ] Messages explain what went wrong
- [ ] Messages are actionable (how to fix)
- [ ] FAILED vs UNAVAILABLE used correctly

### VideoTracker (If applicable)
**Does this touch VideoTracker?**

If YES:
- [ ] Manifest includes `requires_gpu: true`
- [ ] Manifest includes `dependencies` list
- [ ] GPU check doesn't crash (marked UNAVAILABLE)
- [ ] Missing models don't crash (marked UNAVAILABLE)

### No Crashes Guarantee
**Can plugins fail gracefully?**

Manual verification:
- [ ] Tested with intentionally broken plugin
- [ ] Server stayed running
- [ ] Health API still accessible
- [ ] Error properly reported

---

## Testing

### Unit Tests
- [ ] NEW code has unit tests
- [ ] Edge cases covered
- [ ] RED tests written before implementation

### Integration Tests
- [ ] ToolRunner sandbox integration verified
- [ ] Health API tested
- [ ] Plugin loader tested with failures

**Test results:**
```
Tests passed: ___
Coverage: ___%
```

---

## Phase 9/10 Compatibility

- [ ] No UI controls broken
- [ ] No realtime messaging broken
- [ ] No video tracker functionality broken

---

## Final Checklist

- [ ] Code follows Phase 11 developer contract
- [ ] Tests pass: `cd server && uv run pytest`
- [ ] Linting: `cd server && uv run ruff check --fix`
- [ ] Type check: `cd server && uv run mypy app/`
- [ ] No console errors or warnings
- [ ] Commit messages clear
- [ ] PR description complete

---

## Related Issues

Closes #___

---

## Deployment

- [ ] Backward compatible
- [ ] No database migrations
- [ ] No config changes needed
- [ ] Safe to roll back

---

**✓ Ready for review when all boxes checked.**
