### PR TITLE
feat(v0.13.0): Real-time Ray Actors for WebSocket Streaming (Phase C)

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -225,6 +225,26 @@ async def lifespan(app: FastAPI):
     # Disabled in pytest via FORGESYTE_ENABLE_WORKERS=0 to prevent DB lock errors
     if os.getenv("FORGESYTE_ENABLE_WORKERS", "1") == "1":
         try:
+            # v0.13.0: Initialize Ray in main process for WebSocket Actors
+            import ray
+
+            try:
+                if not ray.is_initialized():
+                    ray_address = os.environ.get("RAY_ADDRESS")
+                    if ray_address:
+                        ray.init(address=ray_address, ignore_reinit_error=True)
+                        logger.info(
+                            f"Main process connected to Ray cluster at {ray_address}"
+                        )
+                    else:
+                        ray.init(ignore_reinit_error=True)
+                        logger.info("Main process initialized Ray locally")
+            except Exception as e:
+                logger.warning(
+                    f"Ray not available for WebSocket streaming: {e}. "
+                    "Falling back to local execution."
+                )
+
             from .workers.run_job_worker import run_worker_forever
 
             worker_thread = threading.Thread(
@@ -434,6 +454,8 @@ async def websocket_stream(
     except WebSocketDisconnect:
         pass
     finally:
+        # v0.13.0: Clean up GPU actors when WebSocket disconnects
+        await service.cleanup_client(client_id)
         await ws_manager.disconnect(client_id)
 
 

--- a/server/app/services/vision_analysis.py
+++ b/server/app/services/vision_analysis.py
@@ -1,9 +1,17 @@
 """Vision analysis service for WebSocket streaming.
 
-v0.9.3 — Rewritten to use the unified plugin system.
+v0.13.0 — Upgraded to use Ray Actors for real-time streaming.
 This service is used ONLY for the /v1/stream WebSocket endpoint.
-It performs real-time per-frame analysis by calling plugin.run_tool()
-directly on each incoming frame.
+It performs real-time per-frame analysis using long-lived Ray Actors
+that hold plugin models in GPU memory across frames.
+
+Architecture:
+    WebSocket Frame → VisionAnalysisService → StreamingToolActor (GPU)
+                                                          ↓
+                                                  process_frame.remote()
+                                                          ↓
+                                                  Plugin executed with
+                                                  cached model in VRAM
 
 The service depends on Protocols (PluginRegistry, WebSocketProvider) rather than
 concrete implementations, making it easily testable and extensible.
@@ -22,6 +30,8 @@ import time
 import uuid
 from typing import Any, Dict, List
 
+import ray
+
 from ..protocols import WebSocketProvider
 from .plugin_management_service import PluginManagementService
 
@@ -34,9 +44,17 @@ class VisionAnalysisService:
     Handles the core loop: receiving frames, decoding, timing execution,
     dispatching to plugins, and sending results back to clients.
 
+    v0.13.0: Now uses Ray Actors to cache plugin models in GPU memory
+    across frames, enabling near-zero latency for real-time streaming.
+
     Depends on Protocols for flexibility and testability:
     - PluginManagementService: Abstracts plugin execution
     - WebSocketProvider: Abstracts message delivery mechanism
+
+    Attributes:
+        plugin_service: Plugin management service for executing tools
+        ws_manager: WebSocket manager for client communication
+        active_actors: Dict mapping client_id -> {tool_name: actor_handle}
     """
 
     def __init__(
@@ -53,8 +71,58 @@ class VisionAnalysisService:
         """
         self.plugin_service = plugin_service
         self.ws_manager = ws_manager
+        # Track active Ray actors: client_id -> {tool_name: actor_handle}
+        self.active_actors: Dict[str, Dict[str, Any]] = {}
 
         logger.debug("VisionAnalysisService initialized")
+
+    def _get_or_create_actor(
+        self, client_id: str, plugin_name: str, tool_name: str
+    ) -> Any:
+        """Get or create a Ray Actor for a specific client/tool combination.
+
+        This method implements lazy initialization with caching:
+        - First call creates a new actor
+        - Subsequent calls return the cached actor
+
+        Args:
+            client_id: Unique client identifier
+            plugin_name: Plugin identifier
+            tool_name: Tool name within the plugin
+
+        Returns:
+            Ray Actor handle for the StreamingToolActor
+        """
+        from ..workers.ray_actors import StreamingToolActor
+
+        if client_id not in self.active_actors:
+            self.active_actors[client_id] = {}
+
+        if tool_name not in self.active_actors[client_id]:
+            logger.info(f"Spawning Ray Actor for client {client_id}, tool {tool_name}")
+            # StreamingToolActor.remote is dynamically created by @ray.remote
+            actor = StreamingToolActor.remote(plugin_name, tool_name)  # type: ignore[attr-defined]
+            self.active_actors[client_id][tool_name] = actor
+
+        return self.active_actors[client_id][tool_name]
+
+    async def cleanup_client(self, client_id: str) -> None:
+        """Kill all Ray actors associated with a disconnected client.
+
+        This method MUST be called when a WebSocket disconnects to
+        free GPU VRAM. Otherwise, actors will leak and exhaust GPU memory.
+
+        Args:
+            client_id: Unique client identifier
+        """
+        if client_id in self.active_actors:
+            if ray.is_initialized():
+                for tool_name, actor in self.active_actors[client_id].items():
+                    logger.info(
+                        f"Killing Ray Actor for client {client_id}, tool {tool_name}"
+                    )
+                    ray.kill(actor)
+            del self.active_actors[client_id]
 
     async def handle_frame(
         self, client_id: str, plugin_name: str, data: Dict[str, Any]
@@ -64,9 +132,12 @@ class VisionAnalysisService:
         Orchestrates the complete analysis pipeline:
         1. Decode base64 image data
         2. Time the analysis execution
-        3. Execute plugin analysis
+        3. Execute plugin analysis (via Ray Actor if available)
         4. Send results back to client
         5. Handle errors gracefully
+
+        v0.13.0: Uses Ray Actors for GPU-accelerated streaming when
+        Ray is initialized. Falls back to local execution otherwise.
 
         Args:
             client_id: Unique client identifier
@@ -104,18 +175,31 @@ class VisionAnalysisService:
             if not tools:
                 raise ValueError("WebSocket frame missing 'tools' field")
 
-            # Execute each tool sequentially and collect results per tool
+            # Check if Ray is available for GPU-accelerated streaming
+            use_ray = ray.is_initialized()
+
+            # Execute each tool and collect results
             # v0.10.1: True multi-tool streaming – one frame, many tools, merged result
+            # v0.13.0: Use Ray Actors when available for GPU caching
             merged_results: Dict[str, Any] = {}
             for tool_name in tools:
-                tool_result = self.plugin_service.run_plugin_tool(
-                    plugin_id=plugin_name,
-                    tool_name=tool_name,
-                    args={
-                        "image_bytes": image_bytes,
-                        "options": data.get("options", {}),
-                    },
-                )
+                args = {
+                    "image_bytes": image_bytes,
+                    "options": data.get("options", {}),
+                }
+
+                if use_ray:
+                    # Use cached Ray Actor for GPU-accelerated processing
+                    actor = self._get_or_create_actor(client_id, plugin_name, tool_name)
+                    future = actor.process_frame.remote(args)
+                    tool_result = ray.get(future)
+                else:
+                    # Fallback to local synchronous execution
+                    tool_result = self.plugin_service.run_plugin_tool(
+                        plugin_id=plugin_name,
+                        tool_name=tool_name,
+                        args=args,
+                    )
                 merged_results[tool_name] = tool_result
 
             # Build a canonical multi-tool payload

--- a/server/app/services/vision_analysis.py
+++ b/server/app/services/vision_analysis.py
@@ -71,19 +71,23 @@ class VisionAnalysisService:
         """
         self.plugin_service = plugin_service
         self.ws_manager = ws_manager
-        # Track active Ray actors: client_id -> {tool_name: actor_handle}
-        self.active_actors: Dict[str, Dict[str, Any]] = {}
+        # Track active Ray actors: client_id -> {(plugin_name, tool_name): actor_handle}
+        # Using tuple key prevents cross-plugin reuse when clients switch plugins
+        self.active_actors: Dict[str, Dict[tuple, Any]] = {}
 
         logger.debug("VisionAnalysisService initialized")
 
     def _get_or_create_actor(
         self, client_id: str, plugin_name: str, tool_name: str
     ) -> Any:
-        """Get or create a Ray Actor for a specific client/tool combination.
+        """Get or create a Ray Actor for a specific client/plugin/tool combination.
 
         This method implements lazy initialization with caching:
         - First call creates a new actor
         - Subsequent calls return the cached actor
+
+        v0.13.1: Key now includes plugin_name to prevent cross-plugin reuse
+        when clients switch plugins mid-connection.
 
         Args:
             client_id: Unique client identifier
@@ -98,13 +102,19 @@ class VisionAnalysisService:
         if client_id not in self.active_actors:
             self.active_actors[client_id] = {}
 
-        if tool_name not in self.active_actors[client_id]:
-            logger.info(f"Spawning Ray Actor for client {client_id}, tool {tool_name}")
+        # Use (plugin_name, tool_name) tuple as key to prevent cross-plugin reuse
+        actor_key = (plugin_name, tool_name)
+
+        if actor_key not in self.active_actors[client_id]:
+            logger.info(
+                f"Spawning Ray Actor for client {client_id}, "
+                f"plugin {plugin_name}, tool {tool_name}"
+            )
             # StreamingToolActor.remote is dynamically created by @ray.remote
             actor = StreamingToolActor.remote(plugin_name, tool_name)  # type: ignore[attr-defined]
-            self.active_actors[client_id][tool_name] = actor
+            self.active_actors[client_id][actor_key] = actor
 
-        return self.active_actors[client_id][tool_name]
+        return self.active_actors[client_id][actor_key]
 
     async def cleanup_client(self, client_id: str) -> None:
         """Kill all Ray actors associated with a disconnected client.
@@ -112,14 +122,18 @@ class VisionAnalysisService:
         This method MUST be called when a WebSocket disconnects to
         free GPU VRAM. Otherwise, actors will leak and exhaust GPU memory.
 
+        v0.13.1: Updated to use (plugin_name, tool_name) tuple keys.
+
         Args:
             client_id: Unique client identifier
         """
         if client_id in self.active_actors:
             if ray.is_initialized():
-                for tool_name, actor in self.active_actors[client_id].items():
+                for actor_key, actor in self.active_actors[client_id].items():
+                    plugin_name, tool_name = actor_key
                     logger.info(
-                        f"Killing Ray Actor for client {client_id}, tool {tool_name}"
+                        f"Killing Ray Actor for client {client_id}, "
+                        f"plugin {plugin_name}, tool {tool_name}"
                     )
                     ray.kill(actor)
             del self.active_actors[client_id]
@@ -192,7 +206,9 @@ class VisionAnalysisService:
                     # Use cached Ray Actor for GPU-accelerated processing
                     actor = self._get_or_create_actor(client_id, plugin_name, tool_name)
                     future = actor.process_frame.remote(args)
-                    tool_result = ray.get(future)
+                    # v0.13.1: Await ObjectRef directly instead of blocking ray.get()
+                    # This yields to the event loop, allowing concurrent WebSocket handling
+                    tool_result = await future  # type: ignore[misc]
                 else:
                     # Fallback to local synchronous execution
                     tool_result = self.plugin_service.run_plugin_tool(

--- a/server/app/services/vision_analysis.py
+++ b/server/app/services/vision_analysis.py
@@ -205,10 +205,27 @@ class VisionAnalysisService:
                 if use_ray:
                     # Use cached Ray Actor for GPU-accelerated processing
                     actor = self._get_or_create_actor(client_id, plugin_name, tool_name)
-                    future = actor.process_frame.remote(args)
-                    # v0.13.1: Await ObjectRef directly instead of blocking ray.get()
-                    # This yields to the event loop, allowing concurrent WebSocket handling
-                    tool_result = await future  # type: ignore[misc]
+                    try:
+                        future = actor.process_frame.remote(args)
+                        # v0.13.1: Await ObjectRef directly instead of blocking ray.get()
+                        # This yields to the event loop, allowing concurrent WebSocket handling
+                        tool_result = await future  # type: ignore[misc]
+                    except ray.exceptions.RayActorError as e:
+                        # v0.13.3: Evict poisoned handle - actor failed during init
+                        # This prevents reusing dead actors indefinitely
+                        actor_key = (plugin_name, tool_name)
+                        if (
+                            client_id in self.active_actors
+                            and actor_key in self.active_actors[client_id]
+                        ):
+                            del self.active_actors[client_id][actor_key]
+                            logger.warning(
+                                f"Evicted dead actor for {plugin_name}.{tool_name}",
+                                extra={"client_id": client_id},
+                            )
+                        raise RuntimeError(
+                            f"Ray Actor for {plugin_name}.{tool_name} failed: {e}"
+                        ) from e
                 else:
                     # Fallback to local synchronous execution
                     tool_result = self.plugin_service.run_plugin_tool(

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -59,15 +59,17 @@ class StreamingToolActor:
         Raises:
             RuntimeError: If plugin or tool cannot be loaded
         """
-        from app.plugins.loader.plugin_registry import get_registry
+        from app.plugin_loader import PluginRegistry
         from app.services.plugin_management_service import PluginManagementService
 
         logger.info(f"Initializing StreamingToolActor for {plugin_id}.{tool_name}")
         self.plugin_id = plugin_id
         self.tool_name = tool_name
 
-        # Use singleton registry for consistent state with run_plugin_tool()
-        self.registry = get_registry()
+        # Ray workers run in separate processes - must load plugins locally.
+        # PluginRegistry from app.plugin_loader has load_plugins() method.
+        self.registry = PluginRegistry()
+        self.registry.load_plugins()
         self.plugin_service = PluginManagementService(self.registry)  # type: ignore[arg-type]
 
         # Instantiate plugin and run validation to preload models into VRAM

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -72,18 +72,29 @@ class StreamingToolActor:
         self.registry.load_plugins()
         self.plugin_service = PluginManagementService(self.registry)  # type: ignore[arg-type]
 
-        # Instantiate plugin and run validation to preload models into VRAM
-        # Fail fast if validation fails - don't leave a broken actor alive
-        plugin = self.plugin_service.get_plugin_instance(self.plugin_id)
-        if plugin and hasattr(plugin, "validate"):
-            try:
+        # Instantiate plugin and validate tool exists
+        # Fail fast if plugin/tool cannot be loaded - don't leave a broken actor alive
+        try:
+            plugin = self.plugin_service.get_plugin_instance(self.plugin_id)
+
+            # Validate tool exists in plugin
+            if not hasattr(plugin, "tools") or tool_name not in plugin.tools:
+                available = (
+                    list(plugin.tools.keys()) if hasattr(plugin, "tools") else []
+                )
+                raise ValueError(
+                    f"Tool '{tool_name}' not found in plugin '{plugin_id}'. "
+                    f"Available: {available}"
+                )
+
+            # Run validation to preload models into VRAM
+            if hasattr(plugin, "validate"):
                 plugin.validate()
                 logger.info(f"Plugin {plugin_id} validated, models preloaded into VRAM")
-            except Exception as e:
-                raise RuntimeError(
-                    f"Actor initialization failed for {plugin_id}.{tool_name}: "
-                    f"plugin validation error: {e}"
-                ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Actor initialization failed for {plugin_id}.{tool_name}: {e}"
+            ) from e
 
     def process_frame(self, args: Dict[str, Any]) -> Any:
         """Process a single frame synchronously within the long-lived actor.

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -67,14 +67,14 @@ class StreamingToolActor:
         self.tool_name = tool_name
 
         # Ray workers run in separate processes - must load plugins locally.
-        # PluginRegistry from app.plugin_loader has load_plugins() method.
-        self.registry = PluginRegistry()
-        self.registry.load_plugins()
-        self.plugin_service = PluginManagementService(self.registry)  # type: ignore[arg-type]
-
-        # Instantiate plugin and validate tool exists
-        # Fail fast if plugin/tool cannot be loaded - don't leave a broken actor alive
+        # Wrap entire setup in try to ensure all failures yield RuntimeError.
         try:
+            # PluginRegistry from app.plugin_loader has load_plugins() method.
+            self.registry = PluginRegistry()
+            self.registry.load_plugins()
+            self.plugin_service = PluginManagementService(self.registry)  # type: ignore[arg-type]
+
+            # Instantiate plugin and validate tool exists
             plugin = self.plugin_service.get_plugin_instance(self.plugin_id)
 
             # Validate tool exists in plugin

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -69,7 +69,12 @@ class StreamingToolActor:
         # Ray workers run in separate processes - must load plugins locally.
         # Wrap entire setup in try to ensure all failures yield RuntimeError.
         try:
-            # PluginRegistry from app.plugin_loader has load_plugins() method.
+            # Use PluginRegistry from app.plugin_loader (NOT the singleton from
+            # app.plugins.loader.plugin_registry). This class has load_plugins()
+            # and implements the PluginRegistry Protocol at runtime.
+            # Mypy type ignore: Protocol.get() returns Optional[VisionPlugin],
+            # but concrete class returns Optional[BasePlugin]. At runtime,
+            # BasePlugin satisfies VisionPlugin Protocol.
             self.registry = PluginRegistry()
             self.registry.load_plugins()
             self.plugin_service = PluginManagementService(self.registry)  # type: ignore[arg-type]

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -24,13 +24,11 @@ import ray
 
 logger = logging.getLogger(__name__)
 
-# Note: We omit num_gpus=1 here because a single WebSocket might request
-# multiple tools. Ray scheduling would deadlock if they all demanded a full GPU.
-# Instead, we let Ray's resource scheduler handle GPU allocation based on
-# the actual plugin requirements.
 
-
-@ray.remote
+# Fractional GPU allocation: 0.25 allows up to 4 concurrent actors per GPU.
+# This prevents CPU-only scheduling while avoiding deadlock from full GPU
+# reservation when multiple tools are requested per WebSocket.
+@ray.remote(num_gpus=0.25)
 class StreamingToolActor:
     """Ray Actor for holding plugin state in memory across frames.
 
@@ -82,7 +80,7 @@ class StreamingToolActor:
             except Exception as e:
                 logger.warning(f"Plugin {plugin_id} validation failed: {e}")
 
-    def process_frame(self, args: Dict[str, Any]) -> Dict[str, Any]:
+    def process_frame(self, args: Dict[str, Any]) -> Any:
         """Process a single frame synchronously within the long-lived actor.
 
         This method is called for each incoming frame from the WebSocket.
@@ -94,7 +92,7 @@ class StreamingToolActor:
                 - options: Optional plugin-specific options
 
         Returns:
-            Dict containing the tool execution result
+            Raw result from plugin tool execution (dict, list, str, etc.)
 
         Raises:
             RuntimeError: If tool execution fails
@@ -103,15 +101,7 @@ class StreamingToolActor:
             result = self.plugin_service.run_plugin_tool(
                 self.plugin_id, self.tool_name, args, progress_callback=None
             )
-
-            # Handle Pydantic models
-            if hasattr(result, "model_dump"):
-                return result.model_dump()
-            elif hasattr(result, "dict"):
-                return result.dict()
-
-            return dict(result) if result else {}
-
+            return result
         except Exception as e:
             logger.error(
                 f"StreamingToolActor.process_frame failed for "

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -59,26 +59,29 @@ class StreamingToolActor:
         Raises:
             RuntimeError: If plugin or tool cannot be loaded
         """
-        from app.plugin_loader import PluginRegistry
+        from app.plugins.loader.plugin_registry import get_registry
         from app.services.plugin_management_service import PluginManagementService
 
         logger.info(f"Initializing StreamingToolActor for {plugin_id}.{tool_name}")
         self.plugin_id = plugin_id
         self.tool_name = tool_name
 
-        # Initialize plugin registry and service
-        self.registry = PluginRegistry()
-        self.registry.load_plugins()
-        self.plugin_service = PluginManagementService(self.registry)
+        # Use singleton registry for consistent state with run_plugin_tool()
+        self.registry = get_registry()
+        self.plugin_service = PluginManagementService(self.registry)  # type: ignore[arg-type]
 
-        # Instantiate plugin and run optional validation to preload models
+        # Instantiate plugin and run validation to preload models into VRAM
+        # Fail fast if validation fails - don't leave a broken actor alive
         plugin = self.plugin_service.get_plugin_instance(self.plugin_id)
         if plugin and hasattr(plugin, "validate"):
             try:
                 plugin.validate()
                 logger.info(f"Plugin {plugin_id} validated, models preloaded into VRAM")
             except Exception as e:
-                logger.warning(f"Plugin {plugin_id} validation failed: {e}")
+                raise RuntimeError(
+                    f"Actor initialization failed for {plugin_id}.{tool_name}: "
+                    f"plugin validation error: {e}"
+                ) from e
 
     def process_frame(self, args: Dict[str, Any]) -> Any:
         """Process a single frame synchronously within the long-lived actor.

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -1,0 +1,122 @@
+"""Ray actors for real-time WebSocket streaming (Phase C).
+
+v0.13.0: Long-lived Ray Actors for holding plugin state in GPU memory
+across frames, enabling near-zero latency real-time streaming.
+
+Architecture:
+    WebSocket Frame → VisionAnalysisService → StreamingToolActor (GPU)
+                                                      ↓
+                                              process_frame.remote()
+                                                      ↓
+                                              Plugin executed with
+                                              cached model in VRAM
+
+The Actor lifecycle is managed by VisionAnalysisService:
+    - Created on first frame (lazy initialization)
+    - Reused for subsequent frames (caching)
+    - Killed on WebSocket disconnect (cleanup)
+"""
+
+import logging
+from typing import Any, Dict
+
+import ray
+
+logger = logging.getLogger(__name__)
+
+# Note: We omit num_gpus=1 here because a single WebSocket might request
+# multiple tools. Ray scheduling would deadlock if they all demanded a full GPU.
+# Instead, we let Ray's resource scheduler handle GPU allocation based on
+# the actual plugin requirements.
+
+
+@ray.remote
+class StreamingToolActor:
+    """Ray Actor for holding plugin state in memory across frames.
+
+    This actor is created when a WebSocket client connects and requests
+    a specific tool. The actor loads the plugin once and holds the model
+    in GPU VRAM, enabling near-zero latency for subsequent frames.
+
+    Lifecycle:
+        1. Created by VisionAnalysisService._get_or_create_actor()
+        2. Calls plugin.validate() to preload models into VRAM
+        3. Processes frames via process_frame()
+        4. Killed by VisionAnalysisService.cleanup_client()
+
+    Attributes:
+        plugin_id: The plugin identifier (e.g., "object-tracker")
+        tool_name: The tool name (e.g., "player_detection")
+        registry: PluginRegistry instance for loading plugins
+        plugin_service: PluginManagementService for tool execution
+    """
+
+    def __init__(self, plugin_id: str, tool_name: str):
+        """Initialize the actor with a specific plugin and tool.
+
+        Args:
+            plugin_id: Plugin identifier
+            tool_name: Tool name within the plugin
+
+        Raises:
+            RuntimeError: If plugin or tool cannot be loaded
+        """
+        from app.plugin_loader import PluginRegistry
+        from app.services.plugin_management_service import PluginManagementService
+
+        logger.info(f"Initializing StreamingToolActor for {plugin_id}.{tool_name}")
+        self.plugin_id = plugin_id
+        self.tool_name = tool_name
+
+        # Initialize plugin registry and service
+        self.registry = PluginRegistry()
+        self.registry.load_plugins()
+        self.plugin_service = PluginManagementService(self.registry)
+
+        # Instantiate plugin and run optional validation to preload models
+        plugin = self.plugin_service.get_plugin_instance(self.plugin_id)
+        if plugin and hasattr(plugin, "validate"):
+            try:
+                plugin.validate()
+                logger.info(
+                    f"Plugin {plugin_id} validated, models preloaded into VRAM"
+                )
+            except Exception as e:
+                logger.warning(f"Plugin {plugin_id} validation failed: {e}")
+
+    def process_frame(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Process a single frame synchronously within the long-lived actor.
+
+        This method is called for each incoming frame from the WebSocket.
+        The plugin's model is already loaded in VRAM, so execution is fast.
+
+        Args:
+            args: Arguments dict with:
+                - image_bytes: Raw image bytes
+                - options: Optional plugin-specific options
+
+        Returns:
+            Dict containing the tool execution result
+
+        Raises:
+            RuntimeError: If tool execution fails
+        """
+        try:
+            result = self.plugin_service.run_plugin_tool(
+                self.plugin_id, self.tool_name, args, progress_callback=None
+            )
+
+            # Handle Pydantic models
+            if hasattr(result, "model_dump"):
+                return result.model_dump()
+            elif hasattr(result, "dict"):
+                return result.dict()
+
+            return dict(result) if result else {}
+
+        except Exception as e:
+            logger.error(
+                f"StreamingToolActor.process_frame failed for "
+                f"{self.plugin_id}.{self.tool_name}: {e}"
+            )
+            raise RuntimeError(f"Frame processing failed: {e}") from e

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -78,9 +78,7 @@ class StreamingToolActor:
         if plugin and hasattr(plugin, "validate"):
             try:
                 plugin.validate()
-                logger.info(
-                    f"Plugin {plugin_id} validated, models preloaded into VRAM"
-                )
+                logger.info(f"Plugin {plugin_id} validated, models preloaded into VRAM")
             except Exception as e:
                 logger.warning(f"Plugin {plugin_id} validation failed: {e}")
 

--- a/server/tests/services/test_vision_analysis_actors.py
+++ b/server/tests/services/test_vision_analysis_actors.py
@@ -1,0 +1,233 @@
+"""TDD tests for VisionAnalysisService Ray Actor lifecycle.
+
+v0.13.0 (Phase C): Real-time Ray Actors for WebSocket streaming.
+
+These tests verify the Actor Lifecycle Contract:
+1. CREATE actor on first frame
+2. REUSE actor on subsequent frames (caching)
+3. KILL actor on client disconnect
+
+Acceptance Criteria covered:
+- AC 1: Strict TDD Compliance
+- AC 2: Zero-Latency Frame Processing (Actor Reuse)
+- AC 3: Bulletproof Garbage Collection (VRAM Release)
+- AC 4: Graceful Local Fallback
+- AC 5: Multi-Tool Streaming Support
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class MockRayActorHandle:
+    """Mock Ray Actor handle for testing."""
+
+    def __init__(self, plugin_id: str, tool_name: str):
+        self.plugin_id = plugin_id
+        self.tool_name = tool_name
+        self.process_frame = MagicMock()
+        self.process_frame.remote = MagicMock(return_value="mock_future")
+
+
+class MockStreamingToolActor:
+    """Mock StreamingToolActor class for testing."""
+
+    _instances: list["MockStreamingToolActor"] = []
+    _handle: MockRayActorHandle
+
+    def __init__(self, plugin_id: str, tool_name: str):
+        self.plugin_id = plugin_id
+        self.tool_name = tool_name
+        MockStreamingToolActor._instances.append(self)
+
+    @classmethod
+    def reset(cls):
+        """Reset mock state between tests."""
+        cls._instances = []
+
+    @classmethod
+    def remote(cls, plugin_id: str, tool_name: str):
+        """Mock remote constructor."""
+        instance = cls(plugin_id, tool_name)
+        handle = MockRayActorHandle(plugin_id, tool_name)
+        instance._handle = handle
+        return handle
+
+
+@pytest.fixture(autouse=True)
+def reset_mock_actor():
+    """Reset mock actor state between tests."""
+    MockStreamingToolActor.reset()
+    yield
+
+
+@pytest.mark.asyncio
+async def test_actor_lifecycle_caching_and_cleanup():
+    """Test AC 1, AC 2, AC 3: Actor creation, caching, and cleanup.
+
+    This test verifies:
+    - First frame creates a new actor (AC 2)
+    - Second frame reuses the same actor (AC 2)
+    - cleanup_client kills the actor and removes from tracking (AC 3)
+    """
+    from app.services.vision_analysis import VisionAnalysisService
+
+    # 1. Setup mocks
+    plugin_service = MagicMock()
+    ws_manager = AsyncMock()
+    service = VisionAnalysisService(plugin_service, ws_manager)
+
+    frame_data = {
+        "data": "YmFzZTY0",  # valid base64
+        "tools": ["test_tool"],
+        "options": {},
+    }
+
+    # Mock Ray components
+    with patch("ray.is_initialized", return_value=True):
+        with patch("ray.get", return_value={"mock": "result"}):
+            with patch("ray.kill") as mock_kill:
+                with patch(
+                    "app.workers.ray_actors.StreamingToolActor",
+                    MockStreamingToolActor,
+                ):
+                    # 2. First Frame: Should CREATE the actor
+                    await service.handle_frame("client-123", "test-plugin", frame_data)
+
+                    assert "client-123" in service.active_actors
+                    assert "test_tool" in service.active_actors["client-123"]
+
+                    # 3. Second Frame: Should REUSE the actor (no new instantiation)
+                    await service.handle_frame("client-123", "test-plugin", frame_data)
+
+                    # Verify only one actor was created (caching works)
+                    assert len(MockStreamingToolActor._instances) == 1
+
+                    # 4. Cleanup: Should KILL the actor and remove from tracking dict
+                    await service.cleanup_client("client-123")
+                    mock_kill.assert_called_once()
+                    assert "client-123" not in service.active_actors
+
+
+@pytest.mark.asyncio
+async def test_graceful_local_fallback_when_ray_not_initialized():
+    """Test AC 4: Graceful Local Fallback.
+
+    When Ray is not initialized, the service should fall back to
+    synchronous local execution without attempting to spawn an actor.
+    """
+    from app.services.vision_analysis import VisionAnalysisService
+
+    plugin_service = MagicMock()
+    plugin_service.run_plugin_tool.return_value = {"local": "result"}
+    ws_manager = AsyncMock()
+    service = VisionAnalysisService(plugin_service, ws_manager)
+
+    frame_data = {
+        "data": "YmFzZTY0",  # valid base64
+        "tools": ["test_tool"],
+        "options": {},
+    }
+
+    # Process frame when Ray is not initialized
+    with patch("ray.is_initialized", return_value=False):
+        await service.handle_frame("client-123", "test-plugin", frame_data)
+
+    # Should NOT have created any actors
+    assert "client-123" not in service.active_actors
+
+    # Should have called local plugin_service.run_plugin_tool instead
+    plugin_service.run_plugin_tool.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_multi_tool_streaming_support():
+    """Test AC 5: Multi-Tool Streaming Support.
+
+    When a user selects multiple tools simultaneously, the service
+    should track and create separate Ray Actors under the same client_id.
+    """
+    from app.services.vision_analysis import VisionAnalysisService
+
+    # Setup mocks
+    plugin_service = MagicMock()
+    ws_manager = AsyncMock()
+    service = VisionAnalysisService(plugin_service, ws_manager)
+
+    frame_data = {
+        "data": "YmFzZTY0",  # valid base64
+        "tools": ["player_detection", "ball_detection"],  # Two tools
+        "options": {},
+    }
+
+    # Process frame with multiple tools
+    with patch("ray.is_initialized", return_value=True):
+        with patch("ray.get", return_value={"mock": "result"}):
+            with patch("ray.kill") as mock_kill:
+                with patch(
+                    "app.workers.ray_actors.StreamingToolActor",
+                    MockStreamingToolActor,
+                ):
+                    # Process frame with multiple tools
+                    await service.handle_frame("client-123", "test-plugin", frame_data)
+
+                    # Should have created two actors under the same client_id
+                    assert "client-123" in service.active_actors
+                    assert "player_detection" in service.active_actors["client-123"]
+                    assert "ball_detection" in service.active_actors["client-123"]
+
+                    # Two actors should have been created
+                    assert len(MockStreamingToolActor._instances) == 2
+
+                    # Cleanup should kill both actors
+                    await service.cleanup_client("client-123")
+                    assert mock_kill.call_count == 2  # Both actors killed
+                    assert "client-123" not in service.active_actors
+
+
+@pytest.mark.asyncio
+async def test_actor_isolation_between_clients():
+    """Test that actors are isolated between different clients.
+
+    Each client should have its own set of actors, and cleanup
+    of one client should not affect another.
+    """
+    from app.services.vision_analysis import VisionAnalysisService
+
+    # Setup mocks
+    plugin_service = MagicMock()
+    ws_manager = AsyncMock()
+    service = VisionAnalysisService(plugin_service, ws_manager)
+
+    frame_data = {
+        "data": "YmFzZTY0",
+        "tools": ["test_tool"],
+        "options": {},
+    }
+
+    # Process frames from two different clients
+    with patch("ray.is_initialized", return_value=True):
+        with patch("ray.get", return_value={"mock": "result"}):
+            with patch("ray.kill") as mock_kill:
+                with patch(
+                    "app.workers.ray_actors.StreamingToolActor",
+                    MockStreamingToolActor,
+                ):
+                    await service.handle_frame("client-1", "test-plugin", frame_data)
+                    await service.handle_frame("client-2", "test-plugin", frame_data)
+
+                    # Both clients should have their own actors
+                    assert "client-1" in service.active_actors
+                    assert "client-2" in service.active_actors
+
+                    # Cleanup client-1 should not affect client-2
+                    await service.cleanup_client("client-1")
+                    assert mock_kill.call_count == 1
+                    assert "client-1" not in service.active_actors
+                    assert "client-2" in service.active_actors  # Still there!
+
+                    # Cleanup client-2
+                    await service.cleanup_client("client-2")
+                    assert mock_kill.call_count == 2
+                    assert "client-2" not in service.active_actors

--- a/server/tests/services/test_vision_analysis_actors.py
+++ b/server/tests/services/test_vision_analysis_actors.py
@@ -1,11 +1,13 @@
 """TDD tests for VisionAnalysisService Ray Actor lifecycle.
 
 v0.13.0 (Phase C): Real-time Ray Actors for WebSocket streaming.
+v0.13.1: Fixed actor cache key to include plugin_name.
 
 These tests verify the Actor Lifecycle Contract:
 1. CREATE actor on first frame
 2. REUSE actor on subsequent frames (caching)
 3. KILL actor on client disconnect
+4. Plugin switching creates new actors (v0.13.1)
 
 Acceptance Criteria covered:
 - AC 1: Strict TDD Compliance
@@ -20,6 +22,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+class MockRayObjectRef:
+    """Mock Ray ObjectRef that is awaitable."""
+
+    def __init__(self, result: dict):
+        self._result = result
+
+    def __await__(self):
+        async def _await():
+            return self._result
+
+        return _await().__await__()
+
+
 class MockRayActorHandle:
     """Mock Ray Actor handle for testing."""
 
@@ -27,7 +42,10 @@ class MockRayActorHandle:
         self.plugin_id = plugin_id
         self.tool_name = tool_name
         self.process_frame = MagicMock()
-        self.process_frame.remote = MagicMock(return_value="mock_future")
+        # remote() returns a mock ObjectRef that is awaitable
+        self.process_frame.remote = MagicMock(
+            return_value=MockRayObjectRef({"mock": "result"})
+        )
 
 
 class MockStreamingToolActor:
@@ -86,28 +104,30 @@ async def test_actor_lifecycle_caching_and_cleanup():
 
     # Mock Ray components
     with patch("ray.is_initialized", return_value=True):
-        with patch("ray.get", return_value={"mock": "result"}):
-            with patch("ray.kill") as mock_kill:
-                with patch(
-                    "app.workers.ray_actors.StreamingToolActor",
-                    MockStreamingToolActor,
-                ):
-                    # 2. First Frame: Should CREATE the actor
-                    await service.handle_frame("client-123", "test-plugin", frame_data)
+        with patch("ray.kill") as mock_kill:
+            with patch(
+                "app.workers.ray_actors.StreamingToolActor",
+                MockStreamingToolActor,
+            ):
+                # 2. First Frame: Should CREATE the actor
+                await service.handle_frame("client-123", "test-plugin", frame_data)
 
-                    assert "client-123" in service.active_actors
-                    assert "test_tool" in service.active_actors["client-123"]
+                assert "client-123" in service.active_actors
+                # v0.13.1: Key is now a tuple (plugin_name, tool_name)
+                assert ("test-plugin", "test_tool") in service.active_actors[
+                    "client-123"
+                ]
 
-                    # 3. Second Frame: Should REUSE the actor (no new instantiation)
-                    await service.handle_frame("client-123", "test-plugin", frame_data)
+                # 3. Second Frame: Should REUSE the actor (no new instantiation)
+                await service.handle_frame("client-123", "test-plugin", frame_data)
 
-                    # Verify only one actor was created (caching works)
-                    assert len(MockStreamingToolActor._instances) == 1
+                # Verify only one actor was created (caching works)
+                assert len(MockStreamingToolActor._instances) == 1
 
-                    # 4. Cleanup: Should KILL the actor and remove from tracking dict
-                    await service.cleanup_client("client-123")
-                    mock_kill.assert_called_once()
-                    assert "client-123" not in service.active_actors
+                # 4. Cleanup: Should KILL the actor and remove from tracking dict
+                await service.cleanup_client("client-123")
+                mock_kill.assert_called_once()
+                assert "client-123" not in service.active_actors
 
 
 @pytest.mark.asyncio
@@ -163,27 +183,31 @@ async def test_multi_tool_streaming_support():
 
     # Process frame with multiple tools
     with patch("ray.is_initialized", return_value=True):
-        with patch("ray.get", return_value={"mock": "result"}):
-            with patch("ray.kill") as mock_kill:
-                with patch(
-                    "app.workers.ray_actors.StreamingToolActor",
-                    MockStreamingToolActor,
-                ):
-                    # Process frame with multiple tools
-                    await service.handle_frame("client-123", "test-plugin", frame_data)
+        with patch("ray.kill") as mock_kill:
+            with patch(
+                "app.workers.ray_actors.StreamingToolActor",
+                MockStreamingToolActor,
+            ):
+                # Process frame with multiple tools
+                await service.handle_frame("client-123", "test-plugin", frame_data)
 
-                    # Should have created two actors under the same client_id
-                    assert "client-123" in service.active_actors
-                    assert "player_detection" in service.active_actors["client-123"]
-                    assert "ball_detection" in service.active_actors["client-123"]
+                # Should have created two actors under the same client_id
+                assert "client-123" in service.active_actors
+                # v0.13.1: Keys are now tuples (plugin_name, tool_name)
+                assert ("test-plugin", "player_detection") in service.active_actors[
+                    "client-123"
+                ]
+                assert ("test-plugin", "ball_detection") in service.active_actors[
+                    "client-123"
+                ]
 
-                    # Two actors should have been created
-                    assert len(MockStreamingToolActor._instances) == 2
+                # Two actors should have been created
+                assert len(MockStreamingToolActor._instances) == 2
 
-                    # Cleanup should kill both actors
-                    await service.cleanup_client("client-123")
-                    assert mock_kill.call_count == 2  # Both actors killed
-                    assert "client-123" not in service.active_actors
+                # Cleanup should kill both actors
+                await service.cleanup_client("client-123")
+                assert mock_kill.call_count == 2  # Both actors killed
+                assert "client-123" not in service.active_actors
 
 
 @pytest.mark.asyncio
@@ -208,26 +232,77 @@ async def test_actor_isolation_between_clients():
 
     # Process frames from two different clients
     with patch("ray.is_initialized", return_value=True):
-        with patch("ray.get", return_value={"mock": "result"}):
-            with patch("ray.kill") as mock_kill:
-                with patch(
-                    "app.workers.ray_actors.StreamingToolActor",
-                    MockStreamingToolActor,
-                ):
-                    await service.handle_frame("client-1", "test-plugin", frame_data)
-                    await service.handle_frame("client-2", "test-plugin", frame_data)
+        with patch("ray.kill") as mock_kill:
+            with patch(
+                "app.workers.ray_actors.StreamingToolActor",
+                MockStreamingToolActor,
+            ):
+                await service.handle_frame("client-1", "test-plugin", frame_data)
+                await service.handle_frame("client-2", "test-plugin", frame_data)
 
-                    # Both clients should have their own actors
-                    assert "client-1" in service.active_actors
-                    assert "client-2" in service.active_actors
+                # Both clients should have their own actors
+                assert "client-1" in service.active_actors
+                assert "client-2" in service.active_actors
 
-                    # Cleanup client-1 should not affect client-2
-                    await service.cleanup_client("client-1")
-                    assert mock_kill.call_count == 1
-                    assert "client-1" not in service.active_actors
-                    assert "client-2" in service.active_actors  # Still there!
+                # Cleanup client-1 should not affect client-2
+                await service.cleanup_client("client-1")
+                assert mock_kill.call_count == 1
+                assert "client-1" not in service.active_actors
+                assert "client-2" in service.active_actors  # Still there!
 
-                    # Cleanup client-2
-                    await service.cleanup_client("client-2")
-                    assert mock_kill.call_count == 2
-                    assert "client-2" not in service.active_actors
+                # Cleanup client-2
+                await service.cleanup_client("client-2")
+                assert mock_kill.call_count == 2
+                assert "client-2" not in service.active_actors
+
+
+@pytest.mark.asyncio
+async def test_plugin_switching_creates_new_actor():
+    """Test Issue #277: Plugin switching creates new actor.
+
+    When a client switches plugins mid-connection, the actor cache
+    should create a new actor for the new plugin, not reuse the old one.
+    This prevents running frames against the wrong plugin.
+    """
+    from app.services.vision_analysis import VisionAnalysisService
+
+    # Setup mocks
+    plugin_service = MagicMock()
+    ws_manager = AsyncMock()
+    service = VisionAnalysisService(plugin_service, ws_manager)
+
+    frame_data = {
+        "data": "YmFzZTY0",
+        "tools": ["analyze"],  # Same tool name, different plugins
+        "options": {},
+    }
+
+    # Process frames with different plugins
+    with patch("ray.is_initialized", return_value=True):
+        with patch("ray.kill") as mock_kill:
+            with patch(
+                "app.workers.ray_actors.StreamingToolActor",
+                MockStreamingToolActor,
+            ):
+                # First: Process with plugin A
+                await service.handle_frame("client-1", "plugin-a", frame_data)
+
+                # Should have actor for plugin-a
+                assert ("plugin-a", "analyze") in service.active_actors["client-1"]
+                assert len(MockStreamingToolActor._instances) == 1
+
+                # Now: Switch to plugin B (simulating switch_plugin message)
+                await service.handle_frame("client-1", "plugin-b", frame_data)
+
+                # Should have created a NEW actor for plugin-b
+                # (not reused plugin-a's actor)
+                assert ("plugin-b", "analyze") in service.active_actors["client-1"]
+                assert len(MockStreamingToolActor._instances) == 2  # Two actors now
+
+                # Both should be present (no cleanup on switch)
+                assert ("plugin-a", "analyze") in service.active_actors["client-1"]
+                assert ("plugin-b", "analyze") in service.active_actors["client-1"]
+
+                # Cleanup kills both
+                await service.cleanup_client("client-1")
+                assert mock_kill.call_count == 2


### PR DESCRIPTION
## Summary

Phase C implementation: Upgrade `VisionAnalysisService` to use long-lived Ray Actors that hold plugin models in GPU memory across frames, enabling near-zero latency for real-time streaming.

### Problem (Before v0.13.0)
- Models loaded into GPU VRAM on **every frame**
- Massive latency penalty (800ms+ for model loading)
- Poor real-time streaming experience

### Solution (v0.13.0)
- Ray Actors cache models in GPU memory for WebSocket lifetime
- Actor created on first frame, reused for subsequent frames
- Actor killed on WebSocket disconnect (VRAM freed)

---

## Changes

### New Files
| File | Description |
|------|-------------|
| `server/app/workers/ray_actors.py` | `StreamingToolActor` class for GPU-cached streaming |
| `server/tests/services/test_vision_analysis_actors.py` | TDD tests for Actor lifecycle (4 tests) |

### Modified Files
| File | Changes |
|------|---------|
| `server/app/services/vision_analysis.py` | Added `active_actors`, `_get_or_create_actor()`, `cleanup_client()` |
| `server/app/main.py` | Added Ray init in lifespan, `cleanup_client()` in WebSocket finally |

---

## Test Changes (TDD)

TEST-CHANGE: New test file `test_vision_analysis_actors.py` added to verify Actor lifecycle contract:

| Test | Acceptance Criteria |
|------|---------------------|
| `test_actor_lifecycle_caching_and_cleanup` | AC 1, 2, 3: Create, cache, kill actors |
| `test_graceful_local_fallback_when_ray_not_initialized` | AC 4: Fallback to local execution |
| `test_multi_tool_streaming_support` | AC 5: Multiple actors per client |
| `test_actor_isolation_between_clients` | Actor isolation between clients |

---

## Acceptance Criteria

- [x] **AC 1: Strict TDD Compliance** - Tests written first, all pass
- [x] **AC 2: Zero-Latency Frame Processing** - Actor reuse implemented
- [x] **AC 3: Bulletproof Garbage Collection** - `cleanup_client()` kills actors on disconnect
- [x] **AC 4: Graceful Local Fallback** - Falls back when Ray not initialized
- [x] **AC 5: Multi-Tool Streaming Support** - Multiple actors per client tracked independently

---

## Architecture

```
BEFORE (v0.12.0):
  Frame 1: Init Plugin → Load Weights → Process → Destroy
  Frame 2: Init Plugin → Load Weights → Process → Destroy
  (Latency = Model Load + Inference on EVERY frame)

AFTER (v0.13.0):
  Connect:  Init Plugin → Load Weights (ONCE)
  Frame 1: Process (cached model ⚡)
  Frame 2: Process (cached model ⚡)
  Disconnect: ray.kill() → Free VRAM
  (Latency = Inference ONLY)
```

---

## Verification

```bash
# All checks passed
✅ Pre-commit (black, ruff, mypy, eslint)
✅ Pytest (1543 tests passed)
✅ Execution Governance Scanner
✅ Web-UI Type Check
```

---

## Related

- Discussion: #274
- Plan Comment: https://github.com/rogermt/forgesyte/discussions/274#discussioncomment-16045186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time GPU‑accelerated streaming with per‑client/per‑tool model caching and lazy actor creation for faster frame handling.
  * Startup now initialises/connects to a Ray cluster in the main process with graceful fallback and logged warnings if initialization fails.
  * WebSocket disconnect triggers reliable cleanup to free GPU resources for that client.

* **Tests**
  * Added comprehensive tests covering actor lifecycle, caching, client isolation, fallback behaviour and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->