### PR TITLE
fix(v0.13.1): plugin-aware actor caching and async Ray calls

### DIFF
--- a/server/app/services/vision_analysis.py
+++ b/server/app/services/vision_analysis.py
@@ -71,19 +71,23 @@ class VisionAnalysisService:
         """
         self.plugin_service = plugin_service
         self.ws_manager = ws_manager
-        # Track active Ray actors: client_id -> {tool_name: actor_handle}
-        self.active_actors: Dict[str, Dict[str, Any]] = {}
+        # Track active Ray actors: client_id -> {(plugin_name, tool_name): actor_handle}
+        # Using tuple key prevents cross-plugin reuse when clients switch plugins
+        self.active_actors: Dict[str, Dict[tuple, Any]] = {}
 
         logger.debug("VisionAnalysisService initialized")
 
     def _get_or_create_actor(
         self, client_id: str, plugin_name: str, tool_name: str
     ) -> Any:
-        """Get or create a Ray Actor for a specific client/tool combination.
+        """Get or create a Ray Actor for a specific client/plugin/tool combination.
 
         This method implements lazy initialization with caching:
         - First call creates a new actor
         - Subsequent calls return the cached actor
+
+        v0.13.1: Key now includes plugin_name to prevent cross-plugin reuse
+        when clients switch plugins mid-connection.
 
         Args:
             client_id: Unique client identifier
@@ -98,13 +102,19 @@ class VisionAnalysisService:
         if client_id not in self.active_actors:
             self.active_actors[client_id] = {}
 
-        if tool_name not in self.active_actors[client_id]:
-            logger.info(f"Spawning Ray Actor for client {client_id}, tool {tool_name}")
+        # Use (plugin_name, tool_name) tuple as key to prevent cross-plugin reuse
+        actor_key = (plugin_name, tool_name)
+
+        if actor_key not in self.active_actors[client_id]:
+            logger.info(
+                f"Spawning Ray Actor for client {client_id}, "
+                f"plugin {plugin_name}, tool {tool_name}"
+            )
             # StreamingToolActor.remote is dynamically created by @ray.remote
             actor = StreamingToolActor.remote(plugin_name, tool_name)  # type: ignore[attr-defined]
-            self.active_actors[client_id][tool_name] = actor
+            self.active_actors[client_id][actor_key] = actor
 
-        return self.active_actors[client_id][tool_name]
+        return self.active_actors[client_id][actor_key]
 
     async def cleanup_client(self, client_id: str) -> None:
         """Kill all Ray actors associated with a disconnected client.
@@ -112,14 +122,18 @@ class VisionAnalysisService:
         This method MUST be called when a WebSocket disconnects to
         free GPU VRAM. Otherwise, actors will leak and exhaust GPU memory.
 
+        v0.13.1: Updated to use (plugin_name, tool_name) tuple keys.
+
         Args:
             client_id: Unique client identifier
         """
         if client_id in self.active_actors:
             if ray.is_initialized():
-                for tool_name, actor in self.active_actors[client_id].items():
+                for actor_key, actor in self.active_actors[client_id].items():
+                    plugin_name, tool_name = actor_key
                     logger.info(
-                        f"Killing Ray Actor for client {client_id}, tool {tool_name}"
+                        f"Killing Ray Actor for client {client_id}, "
+                        f"plugin {plugin_name}, tool {tool_name}"
                     )
                     ray.kill(actor)
             del self.active_actors[client_id]
@@ -192,7 +206,9 @@ class VisionAnalysisService:
                     # Use cached Ray Actor for GPU-accelerated processing
                     actor = self._get_or_create_actor(client_id, plugin_name, tool_name)
                     future = actor.process_frame.remote(args)
-                    tool_result = ray.get(future)
+                    # v0.13.1: Await ObjectRef directly instead of blocking ray.get()
+                    # This yields to the event loop, allowing concurrent WebSocket handling
+                    tool_result = await future  # type: ignore[misc]
                 else:
                     # Fallback to local synchronous execution
                     tool_result = self.plugin_service.run_plugin_tool(

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -24,13 +24,11 @@ import ray
 
 logger = logging.getLogger(__name__)
 
-# Note: We omit num_gpus=1 here because a single WebSocket might request
-# multiple tools. Ray scheduling would deadlock if they all demanded a full GPU.
-# Instead, we let Ray's resource scheduler handle GPU allocation based on
-# the actual plugin requirements.
 
-
-@ray.remote
+# Fractional GPU allocation: 0.25 allows up to 4 concurrent actors per GPU.
+# This prevents CPU-only scheduling while avoiding deadlock from full GPU
+# reservation when multiple tools are requested per WebSocket.
+@ray.remote(num_gpus=0.25)
 class StreamingToolActor:
     """Ray Actor for holding plugin state in memory across frames.
 
@@ -82,7 +80,7 @@ class StreamingToolActor:
             except Exception as e:
                 logger.warning(f"Plugin {plugin_id} validation failed: {e}")
 
-    def process_frame(self, args: Dict[str, Any]) -> Dict[str, Any]:
+    def process_frame(self, args: Dict[str, Any]) -> Any:
         """Process a single frame synchronously within the long-lived actor.
 
         This method is called for each incoming frame from the WebSocket.
@@ -94,7 +92,7 @@ class StreamingToolActor:
                 - options: Optional plugin-specific options
 
         Returns:
-            Dict containing the tool execution result
+            Raw result from plugin tool execution (dict, list, str, etc.)
 
         Raises:
             RuntimeError: If tool execution fails
@@ -103,15 +101,7 @@ class StreamingToolActor:
             result = self.plugin_service.run_plugin_tool(
                 self.plugin_id, self.tool_name, args, progress_callback=None
             )
-
-            # Handle Pydantic models
-            if hasattr(result, "model_dump"):
-                return result.model_dump()
-            elif hasattr(result, "dict"):
-                return result.dict()
-
-            return dict(result) if result else {}
-
+            return result
         except Exception as e:
             logger.error(
                 f"StreamingToolActor.process_frame failed for "

--- a/server/tests/services/test_vision_analysis_actors.py
+++ b/server/tests/services/test_vision_analysis_actors.py
@@ -1,11 +1,13 @@
 """TDD tests for VisionAnalysisService Ray Actor lifecycle.
 
 v0.13.0 (Phase C): Real-time Ray Actors for WebSocket streaming.
+v0.13.1: Fixed actor cache key to include plugin_name.
 
 These tests verify the Actor Lifecycle Contract:
 1. CREATE actor on first frame
 2. REUSE actor on subsequent frames (caching)
 3. KILL actor on client disconnect
+4. Plugin switching creates new actors (v0.13.1)
 
 Acceptance Criteria covered:
 - AC 1: Strict TDD Compliance
@@ -20,6 +22,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+class MockRayObjectRef:
+    """Mock Ray ObjectRef that is awaitable."""
+
+    def __init__(self, result: dict):
+        self._result = result
+
+    def __await__(self):
+        async def _await():
+            return self._result
+
+        return _await().__await__()
+
+
 class MockRayActorHandle:
     """Mock Ray Actor handle for testing."""
 
@@ -27,7 +42,10 @@ class MockRayActorHandle:
         self.plugin_id = plugin_id
         self.tool_name = tool_name
         self.process_frame = MagicMock()
-        self.process_frame.remote = MagicMock(return_value="mock_future")
+        # remote() returns a mock ObjectRef that is awaitable
+        self.process_frame.remote = MagicMock(
+            return_value=MockRayObjectRef({"mock": "result"})
+        )
 
 
 class MockStreamingToolActor:
@@ -86,28 +104,30 @@ async def test_actor_lifecycle_caching_and_cleanup():
 
     # Mock Ray components
     with patch("ray.is_initialized", return_value=True):
-        with patch("ray.get", return_value={"mock": "result"}):
-            with patch("ray.kill") as mock_kill:
-                with patch(
-                    "app.workers.ray_actors.StreamingToolActor",
-                    MockStreamingToolActor,
-                ):
-                    # 2. First Frame: Should CREATE the actor
-                    await service.handle_frame("client-123", "test-plugin", frame_data)
+        with patch("ray.kill") as mock_kill:
+            with patch(
+                "app.workers.ray_actors.StreamingToolActor",
+                MockStreamingToolActor,
+            ):
+                # 2. First Frame: Should CREATE the actor
+                await service.handle_frame("client-123", "test-plugin", frame_data)
 
-                    assert "client-123" in service.active_actors
-                    assert "test_tool" in service.active_actors["client-123"]
+                assert "client-123" in service.active_actors
+                # v0.13.1: Key is now a tuple (plugin_name, tool_name)
+                assert ("test-plugin", "test_tool") in service.active_actors[
+                    "client-123"
+                ]
 
-                    # 3. Second Frame: Should REUSE the actor (no new instantiation)
-                    await service.handle_frame("client-123", "test-plugin", frame_data)
+                # 3. Second Frame: Should REUSE the actor (no new instantiation)
+                await service.handle_frame("client-123", "test-plugin", frame_data)
 
-                    # Verify only one actor was created (caching works)
-                    assert len(MockStreamingToolActor._instances) == 1
+                # Verify only one actor was created (caching works)
+                assert len(MockStreamingToolActor._instances) == 1
 
-                    # 4. Cleanup: Should KILL the actor and remove from tracking dict
-                    await service.cleanup_client("client-123")
-                    mock_kill.assert_called_once()
-                    assert "client-123" not in service.active_actors
+                # 4. Cleanup: Should KILL the actor and remove from tracking dict
+                await service.cleanup_client("client-123")
+                mock_kill.assert_called_once()
+                assert "client-123" not in service.active_actors
 
 
 @pytest.mark.asyncio
@@ -163,27 +183,31 @@ async def test_multi_tool_streaming_support():
 
     # Process frame with multiple tools
     with patch("ray.is_initialized", return_value=True):
-        with patch("ray.get", return_value={"mock": "result"}):
-            with patch("ray.kill") as mock_kill:
-                with patch(
-                    "app.workers.ray_actors.StreamingToolActor",
-                    MockStreamingToolActor,
-                ):
-                    # Process frame with multiple tools
-                    await service.handle_frame("client-123", "test-plugin", frame_data)
+        with patch("ray.kill") as mock_kill:
+            with patch(
+                "app.workers.ray_actors.StreamingToolActor",
+                MockStreamingToolActor,
+            ):
+                # Process frame with multiple tools
+                await service.handle_frame("client-123", "test-plugin", frame_data)
 
-                    # Should have created two actors under the same client_id
-                    assert "client-123" in service.active_actors
-                    assert "player_detection" in service.active_actors["client-123"]
-                    assert "ball_detection" in service.active_actors["client-123"]
+                # Should have created two actors under the same client_id
+                assert "client-123" in service.active_actors
+                # v0.13.1: Keys are now tuples (plugin_name, tool_name)
+                assert ("test-plugin", "player_detection") in service.active_actors[
+                    "client-123"
+                ]
+                assert ("test-plugin", "ball_detection") in service.active_actors[
+                    "client-123"
+                ]
 
-                    # Two actors should have been created
-                    assert len(MockStreamingToolActor._instances) == 2
+                # Two actors should have been created
+                assert len(MockStreamingToolActor._instances) == 2
 
-                    # Cleanup should kill both actors
-                    await service.cleanup_client("client-123")
-                    assert mock_kill.call_count == 2  # Both actors killed
-                    assert "client-123" not in service.active_actors
+                # Cleanup should kill both actors
+                await service.cleanup_client("client-123")
+                assert mock_kill.call_count == 2  # Both actors killed
+                assert "client-123" not in service.active_actors
 
 
 @pytest.mark.asyncio
@@ -208,26 +232,77 @@ async def test_actor_isolation_between_clients():
 
     # Process frames from two different clients
     with patch("ray.is_initialized", return_value=True):
-        with patch("ray.get", return_value={"mock": "result"}):
-            with patch("ray.kill") as mock_kill:
-                with patch(
-                    "app.workers.ray_actors.StreamingToolActor",
-                    MockStreamingToolActor,
-                ):
-                    await service.handle_frame("client-1", "test-plugin", frame_data)
-                    await service.handle_frame("client-2", "test-plugin", frame_data)
+        with patch("ray.kill") as mock_kill:
+            with patch(
+                "app.workers.ray_actors.StreamingToolActor",
+                MockStreamingToolActor,
+            ):
+                await service.handle_frame("client-1", "test-plugin", frame_data)
+                await service.handle_frame("client-2", "test-plugin", frame_data)
 
-                    # Both clients should have their own actors
-                    assert "client-1" in service.active_actors
-                    assert "client-2" in service.active_actors
+                # Both clients should have their own actors
+                assert "client-1" in service.active_actors
+                assert "client-2" in service.active_actors
 
-                    # Cleanup client-1 should not affect client-2
-                    await service.cleanup_client("client-1")
-                    assert mock_kill.call_count == 1
-                    assert "client-1" not in service.active_actors
-                    assert "client-2" in service.active_actors  # Still there!
+                # Cleanup client-1 should not affect client-2
+                await service.cleanup_client("client-1")
+                assert mock_kill.call_count == 1
+                assert "client-1" not in service.active_actors
+                assert "client-2" in service.active_actors  # Still there!
 
-                    # Cleanup client-2
-                    await service.cleanup_client("client-2")
-                    assert mock_kill.call_count == 2
-                    assert "client-2" not in service.active_actors
+                # Cleanup client-2
+                await service.cleanup_client("client-2")
+                assert mock_kill.call_count == 2
+                assert "client-2" not in service.active_actors
+
+
+@pytest.mark.asyncio
+async def test_plugin_switching_creates_new_actor():
+    """Test Issue #277: Plugin switching creates new actor.
+
+    When a client switches plugins mid-connection, the actor cache
+    should create a new actor for the new plugin, not reuse the old one.
+    This prevents running frames against the wrong plugin.
+    """
+    from app.services.vision_analysis import VisionAnalysisService
+
+    # Setup mocks
+    plugin_service = MagicMock()
+    ws_manager = AsyncMock()
+    service = VisionAnalysisService(plugin_service, ws_manager)
+
+    frame_data = {
+        "data": "YmFzZTY0",
+        "tools": ["analyze"],  # Same tool name, different plugins
+        "options": {},
+    }
+
+    # Process frames with different plugins
+    with patch("ray.is_initialized", return_value=True):
+        with patch("ray.kill") as mock_kill:
+            with patch(
+                "app.workers.ray_actors.StreamingToolActor",
+                MockStreamingToolActor,
+            ):
+                # First: Process with plugin A
+                await service.handle_frame("client-1", "plugin-a", frame_data)
+
+                # Should have actor for plugin-a
+                assert ("plugin-a", "analyze") in service.active_actors["client-1"]
+                assert len(MockStreamingToolActor._instances) == 1
+
+                # Now: Switch to plugin B (simulating switch_plugin message)
+                await service.handle_frame("client-1", "plugin-b", frame_data)
+
+                # Should have created a NEW actor for plugin-b
+                # (not reused plugin-a's actor)
+                assert ("plugin-b", "analyze") in service.active_actors["client-1"]
+                assert len(MockStreamingToolActor._instances) == 2  # Two actors now
+
+                # Both should be present (no cleanup on switch)
+                assert ("plugin-a", "analyze") in service.active_actors["client-1"]
+                assert ("plugin-b", "analyze") in service.active_actors["client-1"]
+
+                # Cleanup kills both
+                await service.cleanup_client("client-1")
+                assert mock_kill.call_count == 2


### PR DESCRIPTION
<HTML><HEAD></HEAD><BODY><!--StartFragment --><p>Here’s a polished, PR‑ready version of what you wrote — tight, clean, and formatted for a GitHub PR.</p>
<hr />
<h1><strong>Summary</strong></h1>
<p>Four bug fixes for the <strong>v0.13.0 Ray Actor implementation</strong>, addressing correctness, concurrency, GPU scheduling, and result‑type consistency.</p>
<h3><strong>Closes Issue #277 — Actor cache now includes plugin name</strong></h3>
<ul>
<li>Cache key changed from <code>tool_name</code> → <code>(plugin_name, tool_name)</code></li>
<li>Prevents cross‑plugin actor reuse when clients switch tools mid‑stream</li>
<li><code>cleanup_client()</code> now logs both plugin + tool on teardown</li>
</ul>
<h3><strong>Closes Issue #278 — Non‑blocking Ray ObjectRef resolution</strong></h3>
<ul>
<li>Replaced blocking <code>ray.get(future)</code> with <code>await future</code></li>
<li>Allows Ray ObjectRefs to yield to the asyncio event loop</li>
<li>Enables concurrent WebSocket streaming during Ray execution</li>
</ul>
<h3><strong>Closes Issue #280 — GPU resource declaration</strong></h3>
<ul>
<li>Added <code>num_gpus=0.25</code> to <code>@ray.remote</code></li>
<li>Enables fractional GPU allocation (4 actors per GPU)</li>
<li>Prevents CPU‑only scheduling and enforces VRAM locality</li>
</ul>
<h3><strong>Closes Issue #281 — Raw result return from <code>process_frame</code></strong></h3>
<ul>
<li>Return type changed from <code>Dict[str, Any]</code> → <code>Any</code></li>
<li>Removed dict/Pydantic wrapping</li>
<li>Preserves lists, scalars, strings, and <code>None</code></li>
<li>Aligns Ray path with local execution behavior</li>
</ul>
<hr />
<h1><strong>Changes</strong></h1>

File | Changes
-- | --
server/app/services/vision_analysis.py | Tuple‑key caching, async/await
server/app/workers/ray_actors.py | GPU resource declaration, raw result return
server/tests/services/test_vision_analysis_actors.py | Updated tests + new plugin‑switching test


<hr />
<h1><strong>Verification</strong></h1>
<pre><code>✅ black, ruff, mypy, eslint
✅ 5 tests pass
✅ pre-commit hooks pass
</code></pre>
<hr />
<p>Fixes #277, Fixes #278, Fixes #280, Fixes #281</p>
<hr />
<!--EndFragment --></BODY></HTML>