### PR TITLE
fix(v0.13.3): load plugins in Ray worker and evict failed actors

### DIFF
--- a/server/app/services/vision_analysis.py
+++ b/server/app/services/vision_analysis.py
@@ -205,10 +205,27 @@ class VisionAnalysisService:
                 if use_ray:
                     # Use cached Ray Actor for GPU-accelerated processing
                     actor = self._get_or_create_actor(client_id, plugin_name, tool_name)
-                    future = actor.process_frame.remote(args)
-                    # v0.13.1: Await ObjectRef directly instead of blocking ray.get()
-                    # This yields to the event loop, allowing concurrent WebSocket handling
-                    tool_result = await future  # type: ignore[misc]
+                    try:
+                        future = actor.process_frame.remote(args)
+                        # v0.13.1: Await ObjectRef directly instead of blocking ray.get()
+                        # This yields to the event loop, allowing concurrent WebSocket handling
+                        tool_result = await future  # type: ignore[misc]
+                    except ray.exceptions.RayActorError as e:
+                        # v0.13.3: Evict poisoned handle - actor failed during init
+                        # This prevents reusing dead actors indefinitely
+                        actor_key = (plugin_name, tool_name)
+                        if (
+                            client_id in self.active_actors
+                            and actor_key in self.active_actors[client_id]
+                        ):
+                            del self.active_actors[client_id][actor_key]
+                            logger.warning(
+                                f"Evicted dead actor for {plugin_name}.{tool_name}",
+                                extra={"client_id": client_id},
+                            )
+                        raise RuntimeError(
+                            f"Ray Actor for {plugin_name}.{tool_name} failed: {e}"
+                        ) from e
                 else:
                     # Fallback to local synchronous execution
                     tool_result = self.plugin_service.run_plugin_tool(

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -59,15 +59,17 @@ class StreamingToolActor:
         Raises:
             RuntimeError: If plugin or tool cannot be loaded
         """
-        from app.plugins.loader.plugin_registry import get_registry
+        from app.plugin_loader import PluginRegistry
         from app.services.plugin_management_service import PluginManagementService
 
         logger.info(f"Initializing StreamingToolActor for {plugin_id}.{tool_name}")
         self.plugin_id = plugin_id
         self.tool_name = tool_name
 
-        # Use singleton registry for consistent state with run_plugin_tool()
-        self.registry = get_registry()
+        # Ray workers run in separate processes - must load plugins locally.
+        # PluginRegistry from app.plugin_loader has load_plugins() method.
+        self.registry = PluginRegistry()
+        self.registry.load_plugins()
         self.plugin_service = PluginManagementService(self.registry)  # type: ignore[arg-type]
 
         # Instantiate plugin and run validation to preload models into VRAM


### PR DESCRIPTION
## Summary

Two critical bug fixes for v0.13.0 Ray Actor implementation:

### Issue #285: Evict failed actor handles from cache
- Catch RayActorError in handle_frame
- Remove poisoned handle from active_actors
- Prevents reusing dead actors indefinitely until WebSocket disconnect

### Issue #286: Load plugins in Ray worker process
- Ray workers run in separate processes - singletons do not transfer
- Use PluginRegistry from app.plugin_loader - has load_plugins method
- Call load_plugins before accessing registry
- Ensures plugins are available in worker process

---

## Root Causes

### Close Issue #285
Ray actors execute __init__ lazily on first method call. Actor handles were cached before initialization completed. If init failed, the dead handle remained in cache.

### Close Issue #286
The singleton get_registry from health tracking module was used, but it does not have load_plugins. Additionally, Ray workers are separate processes, so even if plugins were loaded in the driver, they would not be available in the worker.

---

## Changes

| File | Changes |
|------|---------|
| server/app/workers/ray_actors.py | Use PluginRegistry from plugin_loader, call load_plugins |
| server/app/services/vision_analysis.py | Catch RayActorError, evict handle on failure |

---

## Verification

```
black, ruff, mypy - passed
5 tests - passed
pre-commit hooks - passed
```

---

Fixes #285, Fixes #286