### PR TITLE
fix(v0.13.4): validate tool existence during actor initialization

### DIFF
--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -72,18 +72,29 @@ class StreamingToolActor:
         self.registry.load_plugins()
         self.plugin_service = PluginManagementService(self.registry)  # type: ignore[arg-type]
 
-        # Instantiate plugin and run validation to preload models into VRAM
-        # Fail fast if validation fails - don't leave a broken actor alive
-        plugin = self.plugin_service.get_plugin_instance(self.plugin_id)
-        if plugin and hasattr(plugin, "validate"):
-            try:
+        # Instantiate plugin and validate tool exists
+        # Fail fast if plugin/tool cannot be loaded - don't leave a broken actor alive
+        try:
+            plugin = self.plugin_service.get_plugin_instance(self.plugin_id)
+
+            # Validate tool exists in plugin
+            if not hasattr(plugin, "tools") or tool_name not in plugin.tools:
+                available = (
+                    list(plugin.tools.keys()) if hasattr(plugin, "tools") else []
+                )
+                raise ValueError(
+                    f"Tool '{tool_name}' not found in plugin '{plugin_id}'. "
+                    f"Available: {available}"
+                )
+
+            # Run validation to preload models into VRAM
+            if hasattr(plugin, "validate"):
                 plugin.validate()
                 logger.info(f"Plugin {plugin_id} validated, models preloaded into VRAM")
-            except Exception as e:
-                raise RuntimeError(
-                    f"Actor initialization failed for {plugin_id}.{tool_name}: "
-                    f"plugin validation error: {e}"
-                ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Actor initialization failed for {plugin_id}.{tool_name}: {e}"
+            ) from e
 
     def process_frame(self, args: Dict[str, Any]) -> Any:
         """Process a single frame synchronously within the long-lived actor.


### PR DESCRIPTION
## Summary

Fixes a fail-fast contract violation in StreamingToolActor initialization.

### Issue #288: Tool existence not validated during init
- Docstring promised `RuntimeError` for invalid tool, but tool was never checked
- Invalid tools would only fail on first `process_frame()` call
- Broken actor would remain cached until WebSocket disconnect

---

## Fix

Validate tool exists in `plugin.tools` dictionary during `__init__`:

1. Check plugin exists
2. Validate `tool_name` in `plugin.tools`
3. Raise `ValueError` with available tools if not found
4. Wrap all init errors in `RuntimeError` for consistent handling

---

## Changes

| File | Changes |
|------|---------|
| `server/app/workers/ray_actors.py` | Add tool validation during init |

---

## Verification

```
black, ruff, mypy - passed
5 tests - passed
pre-commit hooks - passed
```

---

Fixes #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool validation to catch missing or misconfigured tools earlier in the initialisation process, with clearer error messages indicating which tools are available.

* **Performance**
  * Streamlined error handling to fail faster when plugin or tool issues occur, preventing broken actor instances from lingering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->