### PR TITLE
fix(v0.13.5): wrap entire actor setup in try block

### DIFF
--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -67,14 +67,14 @@ class StreamingToolActor:
         self.tool_name = tool_name
 
         # Ray workers run in separate processes - must load plugins locally.
-        # PluginRegistry from app.plugin_loader has load_plugins() method.
-        self.registry = PluginRegistry()
-        self.registry.load_plugins()
-        self.plugin_service = PluginManagementService(self.registry)  # type: ignore[arg-type]
-
-        # Instantiate plugin and validate tool exists
-        # Fail fast if plugin/tool cannot be loaded - don't leave a broken actor alive
+        # Wrap entire setup in try to ensure all failures yield RuntimeError.
         try:
+            # PluginRegistry from app.plugin_loader has load_plugins() method.
+            self.registry = PluginRegistry()
+            self.registry.load_plugins()
+            self.plugin_service = PluginManagementService(self.registry)  # type: ignore[arg-type]
+
+            # Instantiate plugin and validate tool exists
             plugin = self.plugin_service.get_plugin_instance(self.plugin_id)
 
             # Validate tool exists in plugin

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -69,7 +69,12 @@ class StreamingToolActor:
         # Ray workers run in separate processes - must load plugins locally.
         # Wrap entire setup in try to ensure all failures yield RuntimeError.
         try:
-            # PluginRegistry from app.plugin_loader has load_plugins() method.
+            # Use PluginRegistry from app.plugin_loader (NOT the singleton from
+            # app.plugins.loader.plugin_registry). This class has load_plugins()
+            # and implements the PluginRegistry Protocol at runtime.
+            # Mypy type ignore: Protocol.get() returns Optional[VisionPlugin],
+            # but concrete class returns Optional[BasePlugin]. At runtime,
+            # BasePlugin satisfies VisionPlugin Protocol.
             self.registry = PluginRegistry()
             self.registry.load_plugins()
             self.plugin_service = PluginManagementService(self.registry)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Fixes incomplete error handling in StreamingToolActor initialization.

### Issue #290: Actor init try block does not cover full setup
- PluginRegistry, load_plugins, and PluginManagementService were not covered
- Exceptions from these calls escaped as raw exceptions
- Violated documented RuntimeError contract in docstring

## Fix

Move try block to cover entire actor setup including:
1. PluginRegistry construction
2. load_plugins call
3. PluginManagementService construction
4. Plugin instance lookup
5. Tool existence validation
6. Plugin validation

All initialization failures now yield RuntimeError as documented.

## Changes

- server/app/workers/ray_actors.py: Move try block to cover full setup

## Verification

black, ruff, mypy - passed
5 tests - passed
pre-commit hooks - passed

Fixes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling during system initialisation to provide clearer, consolidated error messages when plugin operations fail, enhancing troubleshooting for users experiencing setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

 Issue Created
   - #292

  Fix Applied

  Added detailed comment explaining:

   1. Which PluginRegistry we use: app.plugin_loader.PluginRegistry (has load_plugins(), NOT the singleton)
   2. Why type ignore is needed: Mypy can't verify structural typing matches (VisionPlugin Protocol vs BasePlugin
      concrete class)
   3. Runtime safety: BasePlugin satisfies VisionPlugin Protocol

✦ CodeRabbit confused two classes with the same name:
   - app.plugin_loader.PluginRegistry - correct, has all Protocol methods
   - app.plugins.loader.plugin_registry.PluginRegistry - singleton, raises RuntimeError in __new__()