### PR TITLE
fix(v0.13.10): remove GPU requirement from Ray tasks (Issue #301)

### DIFF
--- a/server/app/ray_tasks.py
+++ b/server/app/ray_tasks.py
@@ -1,12 +1,12 @@
 """Ray remote tasks for distributed plugin execution.
 
 This module provides Ray-decorated functions for executing plugin tools
-in a distributed Ray cluster environment. GPU-heavy plugins (like YOLO)
-can be executed on remote GPU workers while the head node manages job dispatch.
+in a distributed Ray cluster environment. Tasks run on any available
+Ray worker (CPU or GPU). Plugins detect and use GPU at runtime via CUDA.
 
 Architecture:
-    Laptop (Ray Head) --> Lightning AI (GPU Worker)
-                        --> Lightning AI (GPU Worker)
+    Laptop (Ray Head) --> Ray Worker (CPU or GPU)
+                        --> Ray Worker (CPU or GPU)
                         --> ...
 
 The head node dispatches jobs via execute_pipeline_remote.remote() and
@@ -96,11 +96,12 @@ def execute_pipeline_remote(
     input_path: str,
     job_type: str,
 ) -> Dict[str, Any]:
-    """Execute a plugin pipeline on a Ray worker (GPU-enabled).
+    """Execute a plugin pipeline on a Ray worker.
 
-    This function runs on a Ray worker node (e.g., Lightning AI GPU).
-    It downloads the input file from storage, executes the plugin tools,
-    and returns the results.
+    This function runs on any Ray worker node (CPU or GPU). Plugins can
+    detect and use GPU at runtime via CUDA availability. It downloads
+    the input file from storage, executes the plugin tools, and returns
+    the results.
 
     Args:
         plugin_id: Plugin identifier (e.g., "yolo", "ocr")

--- a/server/app/ray_tasks.py
+++ b/server/app/ray_tasks.py
@@ -89,7 +89,7 @@ def _get_storage_service() -> StorageServiceProtocol:
     return get_storage_service(settings)
 
 
-@ray.remote(num_gpus=1)
+@ray.remote(num_gpus=0)
 def execute_pipeline_remote(
     plugin_id: str,
     tools_to_run: List[str],

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -22,6 +22,8 @@ from typing import Any, Dict
 
 import ray
 
+from app.services.device_selector import get_gpu_available
+
 logger = logging.getLogger(__name__)
 
 
@@ -96,8 +98,6 @@ class StreamingToolActor:
             # Run validation to preload models into memory
             if hasattr(plugin, "validate"):
                 plugin.validate()
-                from app.services.device_selector import get_gpu_available
-
                 device_type = "GPU VRAM" if get_gpu_available() else "CPU RAM"
                 logger.info(
                     f"Plugin {plugin_id} validated, models preloaded into {device_type}"

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -25,10 +25,10 @@ import ray
 logger = logging.getLogger(__name__)
 
 
-# Fractional GPU allocation: 0.25 allows up to 4 concurrent actors per GPU.
-# This prevents CPU-only scheduling while avoiding deadlock from full GPU
-# reservation when multiple tools are requested per WebSocket.
-@ray.remote(num_gpus=0.25)
+# No GPU requirement: Allow scheduling on CPU-only clusters.
+# Plugins can detect and use GPU at runtime via CUDA availability.
+# This fixes Issue #301: "No available node types can fulfill resource request {'GPU': 1.0}"
+@ray.remote(num_gpus=0)
 class StreamingToolActor:
     """Ray Actor for holding plugin state in memory across frames.
 

--- a/server/app/workers/ray_actors.py
+++ b/server/app/workers/ray_actors.py
@@ -1,15 +1,15 @@
 """Ray actors for real-time WebSocket streaming (Phase C).
 
-v0.13.0: Long-lived Ray Actors for holding plugin state in GPU memory
-across frames, enabling near-zero latency real-time streaming.
+v0.13.0: Long-lived Ray Actors for holding plugin state in memory
+across frames, enabling low-latency real-time streaming.
 
 Architecture:
-    WebSocket Frame → VisionAnalysisService → StreamingToolActor (GPU)
+    WebSocket Frame → VisionAnalysisService → StreamingToolActor (CPU or GPU)
                                                       ↓
                                               process_frame.remote()
                                                       ↓
                                               Plugin executed with
-                                              cached model in VRAM
+                                              cached model (GPU VRAM or CPU RAM)
 
 The Actor lifecycle is managed by VisionAnalysisService:
     - Created on first frame (lazy initialization)
@@ -34,11 +34,12 @@ class StreamingToolActor:
 
     This actor is created when a WebSocket client connects and requests
     a specific tool. The actor loads the plugin once and holds the model
-    in GPU VRAM, enabling near-zero latency for subsequent frames.
+    in memory (GPU VRAM if available, otherwise CPU RAM), enabling
+    low-latency processing for subsequent frames.
 
     Lifecycle:
         1. Created by VisionAnalysisService._get_or_create_actor()
-        2. Calls plugin.validate() to preload models into VRAM
+        2. Calls plugin.validate() to preload models into memory
         3. Processes frames via process_frame()
         4. Killed by VisionAnalysisService.cleanup_client()
 
@@ -92,10 +93,15 @@ class StreamingToolActor:
                     f"Available: {available}"
                 )
 
-            # Run validation to preload models into VRAM
+            # Run validation to preload models into memory
             if hasattr(plugin, "validate"):
                 plugin.validate()
-                logger.info(f"Plugin {plugin_id} validated, models preloaded into VRAM")
+                from app.services.device_selector import get_gpu_available
+
+                device_type = "GPU VRAM" if get_gpu_available() else "CPU RAM"
+                logger.info(
+                    f"Plugin {plugin_id} validated, models preloaded into {device_type}"
+                )
         except Exception as e:
             raise RuntimeError(
                 f"Actor initialization failed for {plugin_id}.{tool_name}: {e}"
@@ -105,7 +111,7 @@ class StreamingToolActor:
         """Process a single frame synchronously within the long-lived actor.
 
         This method is called for each incoming frame from the WebSocket.
-        The plugin's model is already loaded in VRAM, so execution is fast.
+        The plugin's model is already loaded in memory, so execution is fast.
 
         Args:
             args: Arguments dict with:

--- a/server/tests/test_ray_tasks.py
+++ b/server/tests/test_ray_tasks.py
@@ -260,6 +260,26 @@ class TestRayTaskDecorator:
         assert hasattr(execute_pipeline_remote, "remote")
         assert callable(execute_pipeline_remote.remote)
 
+    def test_execute_pipeline_remote_no_gpu_requirement(self):
+        """Verify execute_pipeline_remote doesn't require GPU (Issue #301).
+
+        Ray tasks should be schedulable on CPU-only clusters. Plugins can
+        use GPU via CUDA detection if available. Hardcoding num_gpus=1
+        blocks execution on clusters without GPU nodes.
+
+        Error: "No available node types can fulfill resource request {'GPU': 1.0}"
+        """
+        from app.ray_tasks import execute_pipeline_remote
+
+        # Ray remote functions store decorator options in _default_options
+        # num_gpus should be 0 (no GPU requirement) or not set
+        num_gpus = execute_pipeline_remote._default_options.get("num_gpus", 0)
+        assert num_gpus == 0, (
+            f"execute_pipeline_remote has num_gpus={num_gpus}, "
+            "which blocks CPU-only clusters. Set num_gpus=0 to allow "
+            "scheduling on any node (plugins can detect GPU at runtime)."
+        )
+
 
 class TestStorageIntegration:
     """Tests for storage integration in Ray tasks."""


### PR DESCRIPTION
## Summary
- Removes hardcoded `num_gpus=1` from `execute_pipeline_remote` Ray task
- Removes `num_gpus=0.25` from `StreamingToolActor` Ray actor
- Adds TDD test to prevent regression

## Problem
Ray tasks with `num_gpus=1` blocked execution on CPU-only clusters:
```
Error: No available node types can fulfill resource request {'GPU': 1.0}
```

## Solution
Set `num_gpus=0` to allow scheduling on any node. Plugins can detect and use GPU at runtime via CUDA availability.

## Test plan
- [x] TDD: Write failing test first
- [x] Fix code
- [x] Test passes: `uv run pytest tests/test_ray_tasks.py -v` (13 passed)

Closes #301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Lowered explicit GPU resource requests so tasks and actors can be scheduled on CPU-only nodes while still allowing runtime GPU acceleration; logging and docs updated to reflect device‑agnostic, in‑memory model loading.

* **Tests**
  * Added a unit test to verify the resource configuration supports CPU‑only scheduling and runtime detection of available GPUs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->