### PR TITLE
v0.14.0: Drop Ray integration, restore synchronous job execution

### DIFF
--- a/server/app/workers/run_job_worker.py
+++ b/server/app/workers/run_job_worker.py
@@ -17,7 +17,7 @@ from app.plugin_loader import PluginRegistry  # noqa: E402
 from app.services.plugin_management_service import PluginManagementService  # noqa: E402
 from app.services.storage.factory import get_storage_service  # noqa: E402
 from app.settings import settings  # noqa: E402
-from app.workers.worker import JobWorker, init_ray  # noqa: E402
+from app.workers.worker import JobWorker  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -38,17 +38,10 @@ def run_worker_forever(plugin_manager: PluginRegistry):
     storage = get_storage_service(settings)
     plugin_service = PluginManagementService(plugin_manager)
 
-    # v0.12.0: Initialize Ray if available (Issue #269)
-    use_ray = init_ray()
-    if use_ray:
-        logger.info("Ray initialized successfully, enabling GPU-accelerated execution")
-    else:
-        logger.info("Ray not available, using synchronous execution")
-
+    # v0.14.0: Ray disabled - using synchronous execution (Issue #321)
     worker = JobWorker(
         storage=storage,
         plugin_service=plugin_service,
-        use_ray=use_ray,
     )
 
     logger.info("JobWorker thread initialized")
@@ -68,19 +61,10 @@ def main():
         storage = get_storage_service(settings)
         plugin_service = PluginManagementService(plugin_manager)
 
-        # v0.12.0: Initialize Ray if available (Issue #269)
-        use_ray = init_ray()
-        if use_ray:
-            logger.info(
-                "Ray initialized successfully, enabling GPU-accelerated execution"
-            )
-        else:
-            logger.info("Ray not available, using synchronous execution")
-
+        # v0.14.0: Ray disabled - using synchronous execution (Issue #321)
         worker = JobWorker(
             storage=storage,
             plugin_service=plugin_service,
-            use_ray=use_ray,
         )
 
         logger.info("JobWorker initialized")


### PR DESCRIPTION
## Summary

This PR disables Ray integration in the JobWorker and restores synchronous job execution as the default.

## Why Drop Ray?

The Ray integration introduced significant operational complexity without proportional benefit:

- Ray cluster state recovery
- DuckDB schema drift
- GCS credential churn  
- GPU scheduling complexity
- Memory pressure issues
- Ray runtime_env propagation
- Ray future tracking
- Ray orphan recovery
- Ray startup failures
- Ray worker heartbeats
- Ray object store limits

The overhead of maintaining Ray infrastructure outweighed the benefits for this workload. Synchronous execution is simpler, more reliable, and easier to debug.

## Fixes

### 1. Disable Ray in JobWorker (Issue #321)
- Removed `init_ray()` calls from `run_job_worker.py`
- Removed `use_ray` parameter from `JobWorker()` calls (now defaults to `False`)
- Removed misleading "GPU-accelerated execution" log messages



## Testing

- All 1577 tests pass
- No Ray dependency for basic job execution

## Note

This is NOT a revert to v0.11.1. Many fixes have been applied since Ray was introduced that we want to keep:
- Manifest tool extraction consolidation
- Plugin loading improvements
- Job progress tracking
- Video pipeline fixes
- And more

Closes #321