### PR TITLE
fix: resolve CodeRabbit AI issues and Discussion #335

### DIFF
--- a/server/app/api_routes/routes/image_submit.py
+++ b/server/app/api_routes/routes/image_submit.py
@@ -123,39 +123,24 @@ async def submit_image(
     plugin_service=Depends(get_plugin_service),
     storage=Depends(get_storage),
 ):
-    """Submit an image file for processing.
-
-    This endpoint creates a new job with job_type="image" (single tool) or
-    job_type="image_multi" (multiple tools) and enqueues it for processing
-    by the worker.
-
-    v0.9.4: Supports multiple tools via repeated query parameters.
-    Example: ?tool=player_detection&tool=ball_detection
-
-    v0.9.7: Supports logical_tool_id parameter for capability-based resolution.
-    The logical tool ID (capability string) is matched against tool capabilities
-    in the manifest to find the actual plugin tool ID.
-
-    v0.9.8: Mutual exclusivity - cannot provide both tool and logical_tool_id.
-    Canonical JSON response with submitted_at, tools array for multi-tool.
-
-    Args:
-        file: Image file (PNG or JPEG) to process
-        plugin_id: ID of the plugin to use (from /v1/plugins)
-        tool: Tool ID(s) to run (from plugin manifest). Can be repeated for multi-tool.
-            Optional if logical_tool_id is provided.
-        logical_tool_id: Logical tool ID(s) (capability strings) for dynamic resolution.
-            Repeatable for multi-tool. e.g., "player_detection", "ball_detection"
-        plugin_manager: PluginRegistry from app state (DI)
-        plugin_service: PluginManagementService instance (DI)
-
+    """
+    Submit an image for processing by a plugin and create a queued job.
+    
+    Either `tool` or `logical_tool_id` must be provided (they are mutually exclusive). If `logical_tool_id` is used, capability-based resolution determines concrete tool ID(s). The created job will be enqueued and a canonical JSON summary is returned.
+    
+    Parameters:
+        plugin_id (str): Plugin identifier (from /v1/plugins).
+        tool (List[str] | None): Explicit plugin tool ID(s); repeatable for multi-tool requests. Optional when `logical_tool_id` is provided.
+        logical_tool_id (List[str] | None): Logical capability strings to resolve into concrete tool ID(s); repeatable for multi-tool requests.
+    
     Returns:
-        Canonical JSON:
-        - Single tool: {"job_id": "...", "plugin": "...", "tool": "...", "status": "queued", "submitted_at": "..."}
-        - Multi tool: {"job_id": "...", "plugin": "...", "tools": [...], "status": "queued", "submitted_at": "..."}
-
+        dict: Canonical JSON describing the queued job:
+            - Always includes: `job_id` (string), `plugin` (plugin_id), `status` ("queued"), and `submitted_at` (ISO 8601 UTC string).
+            - If a single tool was selected: includes `tool` with the resolved tool ID.
+            - If multiple tools were selected: includes `tools` (either a list of resolved tool IDs for explicit `tool` requests, or a list of {"logical": ..., "resolved": ...} mappings when `logical_tool_id` was used).
+    
     Raises:
-        HTTPException: If file is invalid or processing fails
+        HTTPException: For invalid input (missing plugin, invalid/mutually exclusive parameters, unsupported tools or non-image files) or other request-time validation errors.
     """
     # DEBUG: Log incoming request parameters
     debug_file(
@@ -306,6 +291,11 @@ async def submit_image(
         reraise=True,
     )
     async def save_file_with_retry():
+        """
+        Save the in-memory image bytes to the configured storage backend at the designated destination path.
+        
+        The coroutine wraps the captured `contents` in a `BytesIO` and invokes `storage.save_file` on a worker thread so the I/O does not block the event loop.
+        """
         await asyncio.to_thread(
             storage.save_file, src=BytesIO(contents), dest_path=input_path
         )

--- a/server/app/api_routes/routes/image_submit.py
+++ b/server/app/api_routes/routes/image_submit.py
@@ -125,20 +125,20 @@ async def submit_image(
 ):
     """
     Submit an image for processing by a plugin and create a queued job.
-    
+
     Either `tool` or `logical_tool_id` must be provided (they are mutually exclusive). If `logical_tool_id` is used, capability-based resolution determines concrete tool ID(s). The created job will be enqueued and a canonical JSON summary is returned.
-    
+
     Parameters:
         plugin_id (str): Plugin identifier (from /v1/plugins).
         tool (List[str] | None): Explicit plugin tool ID(s); repeatable for multi-tool requests. Optional when `logical_tool_id` is provided.
         logical_tool_id (List[str] | None): Logical capability strings to resolve into concrete tool ID(s); repeatable for multi-tool requests.
-    
+
     Returns:
         dict: Canonical JSON describing the queued job:
             - Always includes: `job_id` (string), `plugin` (plugin_id), `status` ("queued"), and `submitted_at` (ISO 8601 UTC string).
             - If a single tool was selected: includes `tool` with the resolved tool ID.
             - If multiple tools were selected: includes `tools` (either a list of resolved tool IDs for explicit `tool` requests, or a list of {"logical": ..., "resolved": ...} mappings when `logical_tool_id` was used).
-    
+
     Raises:
         HTTPException: For invalid input (missing plugin, invalid/mutually exclusive parameters, unsupported tools or non-image files) or other request-time validation errors.
     """
@@ -293,7 +293,7 @@ async def submit_image(
     async def save_file_with_retry():
         """
         Save the in-memory image bytes to the configured storage backend at the designated destination path.
-        
+
         The coroutine wraps the captured `contents` in a `BytesIO` and invokes `storage.save_file` on a worker thread so the I/O does not block the event loop.
         """
         await asyncio.to_thread(

--- a/server/app/api_routes/routes/image_submit.py
+++ b/server/app/api_routes/routes/image_submit.py
@@ -18,6 +18,7 @@ from typing import List
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 from app.core.database import SessionLocal
 from app.models.job import Job, JobStatus
@@ -290,14 +291,24 @@ async def submit_image(
     job_id = uuid4()
     input_path = f"image/input/{job_id}_{file.filename}"
 
-    # Save file to storage
-    try:
+    # Save file to storage with retry logic (Issue #332)
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+        reraise=True,
+    )
+    def save_file_with_retry():
         storage.save_file(src=BytesIO(contents), dest_path=input_path)
+
+    try:
+        save_file_with_retry()
         debug_file(f"[DEBUG] File saved to {input_path}")
         logger.info(f"[DEBUG] File saved to {input_path}")
     except Exception as e:
-        debug_file(f"[DEBUG] Storage save failed: {e}")
-        logger.error(f"[DEBUG] Storage save failed: {e}\n{traceback.format_exc()}")
+        debug_file(f"[DEBUG] Storage save failed after retries: {e}")
+        logger.error(
+            f"[DEBUG] Storage save failed after retries: {e}\n{traceback.format_exc()}"
+        )
         raise
 
     # Create database record
@@ -373,6 +384,16 @@ async def submit_image(
             "submitted_at": submitted_at,
         }
 
-    # Legacy (tool=...) callers get basic response
-    debug_file(f"[DEBUG] Returning legacy response: job_id={job_id}")
-    return {"job_id": str(job_id)}
+    # Legacy (tool=...) callers - return canonical JSON (Issue #333)
+    debug_file(f"[DEBUG] Returning explicit-tool response: job_id={job_id}")
+    response = {
+        "job_id": str(job_id),
+        "plugin": plugin_id,
+        "status": "queued",
+        "submitted_at": submitted_at,
+    }
+    if len(resolved_tools) > 1:
+        response["tools"] = resolved_tools
+    else:
+        response["tool"] = resolved_tools[0]
+    return response

--- a/server/app/api_routes/routes/image_submit.py
+++ b/server/app/api_routes/routes/image_submit.py
@@ -9,6 +9,7 @@ v0.9.8: Added mutual exclusivity check (tool vs logical_tool_id),
         repeatable logical_tool_id, and canonical JSON response.
 """
 
+import asyncio
 import json
 import logging
 import traceback
@@ -18,7 +19,12 @@ from typing import List
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from app.core.database import SessionLocal
 from app.models.job import Job, JobStatus
@@ -291,17 +297,21 @@ async def submit_image(
     job_id = uuid4()
     input_path = f"image/input/{job_id}_{file.filename}"
 
-    # Save file to storage with retry logic (Issue #332)
+    # Save file to storage with async retry logic (Issue #332, #337)
+    # Only retry on transient errors (ConnectionError, TimeoutError)
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10),
+        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
         reraise=True,
     )
-    def save_file_with_retry():
-        storage.save_file(src=BytesIO(contents), dest_path=input_path)
+    async def save_file_with_retry():
+        await asyncio.to_thread(
+            storage.save_file, src=BytesIO(contents), dest_path=input_path
+        )
 
     try:
-        save_file_with_retry()
+        await save_file_with_retry()
         debug_file(f"[DEBUG] File saved to {input_path}")
         logger.info(f"[DEBUG] File saved to {input_path}")
     except Exception as e:

--- a/server/app/api_routes/routes/jobs.py
+++ b/server/app/api_routes/routes/jobs.py
@@ -159,9 +159,14 @@ async def get_job(job_id: UUID, db: Session = Depends(get_db)) -> JobResultsResp
             # Calculate which tool is running based on progress
             # Each tool gets equal weight (100/total_tools)
             tool_weight = 100 / tools_total
-            tools_completed = int(job.progress / tool_weight)
-            # Clamp to valid range
-            tools_completed = max(0, min(tools_total - 1, tools_completed))
+            # Issue #334: Use boundary comparison to avoid truncation bug
+            # Boundaries mark where each tool completes: [33, 66] for 3 tools
+            boundaries = [
+                int((index + 1) * tool_weight) for index in range(tools_total - 1)
+            ]
+            tools_completed = sum(
+                1 for boundary in boundaries if job.progress >= boundary
+            )
             # Current tool is the next one after completed
             if tools_completed < tools_total:
                 current_tool = tools[tools_completed]

--- a/server/app/api_routes/routes/video_submit.py
+++ b/server/app/api_routes/routes/video_submit.py
@@ -242,21 +242,21 @@ async def submit_video(
 ):
     """
     Submit an MP4 video to a plugin and create a queued job for processing.
-    
+
     Validates the plugin, resolves tool IDs from either explicit `tool` values or capability-based `logical_tool_id` (mutually exclusive), ensures each resolved tool supports video input, saves the uploaded MP4 to storage, creates a job record with job_type "video" or "video_multi", attaches the tools to the job, and returns a canonical JSON summary of the queued job.
-    
+
     Parameters:
         file: UploadFile containing the MP4 video to process.
         plugin_id (str): Plugin identifier.
         tool (List[str] | None): Concrete tool ID(s) from the plugin manifest. Repeatable for multi-tool; optional if `logical_tool_id` is provided.
         logical_tool_id (List[str] | None): Logical capability strings used to resolve concrete tool ID(s). Repeatable for multi-tool.
-    
+
     Returns:
         dict: Canonical JSON describing the queued job.
         - Single tool: {"job_id": "<uuid>", "plugin": "<plugin_id>", "tool": "<tool_id>", "status": "queued", "submitted_at": "<ISO-8601 Z>"}.
         - Multi tool: {"job_id": "<uuid>", "plugin": "<plugin_id>", "tools": [...], "status": "queued", "submitted_at": "<ISO-8601 Z>"}.
         - When `logical_tool_id` was used and multiple logicals were provided, the "tools" array contains objects with "logical" and "resolved" entries.
-    
+
     Raises:
         HTTPException: For validation failures such as missing plugin, mutually exclusive parameters, unresolved tools, manifest or tool definition issues, tools that do not accept video, invalid MP4 content, or missing file.
     """

--- a/server/app/api_routes/routes/video_submit.py
+++ b/server/app/api_routes/routes/video_submit.py
@@ -240,36 +240,25 @@ async def submit_video(
     plugin_manager=Depends(get_plugin_manager),
     plugin_service=Depends(get_plugin_service),
 ):
-    """Submit a video file for processing.
-
-    This endpoint creates a new job with job_type="video" (single tool) or
-    job_type="video_multi" (multiple tools) and enqueues it for processing
-    by the worker.
-
-    v0.9.7: Supports logical_tool_id parameter for capability-based resolution.
-    The logical tool ID (capability string) is matched against tool capabilities
-    in the manifest to find the actual plugin tool ID.
-
-    v0.9.8: Mutual exclusivity - cannot provide both tool and logical_tool_id.
-    Canonical JSON response with submitted_at, tools array for multi-tool.
-
-    Args:
-        file: MP4 video file to process
-        plugin_id: ID of the plugin to use (from /v1/plugins)
-        tool: Tool ID(s) to run (from plugin manifest). Can be repeated for multi-tool.
-            Optional if logical_tool_id is provided.
-        logical_tool_id: Logical tool ID(s) (capability strings) for dynamic resolution.
-            Repeatable for multi-tool. e.g., "player_detection", "ball_detection"
-        plugin_manager: PluginRegistry from app state (DI)
-        plugin_service: PluginManagementService instance (DI)
-
+    """
+    Submit an MP4 video to a plugin and create a queued job for processing.
+    
+    Validates the plugin, resolves tool IDs from either explicit `tool` values or capability-based `logical_tool_id` (mutually exclusive), ensures each resolved tool supports video input, saves the uploaded MP4 to storage, creates a job record with job_type "video" or "video_multi", attaches the tools to the job, and returns a canonical JSON summary of the queued job.
+    
+    Parameters:
+        file: UploadFile containing the MP4 video to process.
+        plugin_id (str): Plugin identifier.
+        tool (List[str] | None): Concrete tool ID(s) from the plugin manifest. Repeatable for multi-tool; optional if `logical_tool_id` is provided.
+        logical_tool_id (List[str] | None): Logical capability strings used to resolve concrete tool ID(s). Repeatable for multi-tool.
+    
     Returns:
-        Canonical JSON:
-        - Single tool: {"job_id": "...", "plugin": "...", "tool": "...", "status": "queued", "submitted_at": "..."}
-        - Multi tool: {"job_id": "...", "plugin": "...", "tools": [...], "status": "queued", "submitted_at": "..."}
-
+        dict: Canonical JSON describing the queued job.
+        - Single tool: {"job_id": "<uuid>", "plugin": "<plugin_id>", "tool": "<tool_id>", "status": "queued", "submitted_at": "<ISO-8601 Z>"}.
+        - Multi tool: {"job_id": "<uuid>", "plugin": "<plugin_id>", "tools": [...], "status": "queued", "submitted_at": "<ISO-8601 Z>"}.
+        - When `logical_tool_id` was used and multiple logicals were provided, the "tools" array contains objects with "logical" and "resolved" entries.
+    
     Raises:
-        HTTPException: If file is invalid or processing fails
+        HTTPException: For validation failures such as missing plugin, mutually exclusive parameters, unresolved tools, manifest or tool definition issues, tools that do not accept video, invalid MP4 content, or missing file.
     """
     # Validate plugin exists
     plugin = plugin_manager.get(plugin_id)

--- a/server/app/api_routes/routes/video_submit.py
+++ b/server/app/api_routes/routes/video_submit.py
@@ -437,5 +437,15 @@ async def submit_video(
             "submitted_at": submitted_at,
         }
 
-    # Legacy (tool=...) callers get basic response
-    return {"job_id": str(job_id)}
+    # Legacy (tool=...) callers - return canonical JSON (Issue #333)
+    response = {
+        "job_id": str(job_id),
+        "plugin": plugin_id,
+        "status": "queued",
+        "submitted_at": submitted_at,
+    }
+    if len(resolved_tools) > 1:
+        response["tools"] = resolved_tools
+    else:
+        response["tool"] = resolved_tools[0]
+    return response

--- a/server/tests/api/routes/test_image_submit.py
+++ b/server/tests/api/routes/test_image_submit.py
@@ -635,7 +635,7 @@ class TestImageSubmitCanonicalJson:
     def test_canonical_json_legacy_tool_path(self, mock_plugin, session: Session):
         """
         Verify that the legacy tool= submission path returns the canonical JSON response including job_id, plugin, tool, status and submitted_at.
-        
+
         Submits a PNG file using the legacy query parameters (plugin_id and tool) and asserts a 200 response, presence of the canonical fields, and that `submitted_at` is an ISO 8601 UTC timestamp ending with 'Z'.
         """
         plugin = MagicMock()
@@ -655,7 +655,7 @@ class TestImageSubmitCanonicalJson:
         def override_get_plugin_manager():
             """
             Provide the mocked plugin registry to use as the application's plugin manager override.
-            
+
             Returns:
                 mock_registry: The mocked plugin registry instance to be injected as the plugin manager.
             """
@@ -664,7 +664,7 @@ class TestImageSubmitCanonicalJson:
         def override_get_plugin_service():
             """
             Provide the mocked plugin service used for dependency injection in tests.
-            
+
             Returns:
                 The mocked plugin service instance (`mock_service`) supplied by the test fixture.
             """
@@ -734,10 +734,10 @@ class TestImageSubmitStorageRetry:
         def mock_save_file(*args, **kwargs):
             """
             Simulate a storage save operation that fails once with a transient network error and then succeeds.
-            
+
             Returns:
                 str: The saved file path ("image/input/test.png") on successful save.
-            
+
             Raises:
                 ConnectionError: On the first invocation to simulate a transient network error.
             """
@@ -754,7 +754,7 @@ class TestImageSubmitStorageRetry:
         def override_get_plugin_manager():
             """
             Provide the mocked plugin registry to use as the application's plugin manager override.
-            
+
             Returns:
                 mock_registry: The mocked plugin registry instance to be injected as the plugin manager.
             """
@@ -763,7 +763,7 @@ class TestImageSubmitStorageRetry:
         def override_get_plugin_service():
             """
             Provide the mocked plugin service used for dependency injection in tests.
-            
+
             Returns:
                 The mocked plugin service instance (`mock_service`) supplied by the test fixture.
             """
@@ -772,7 +772,7 @@ class TestImageSubmitStorageRetry:
         def override_get_storage():
             """
             Provide the mock storage instance for dependency overrides in tests.
-            
+
             Returns:
                 mock_storage: The mock storage object used by tests, exposing the same public methods as the production storage implementation (e.g. `save_file`).
             """
@@ -830,7 +830,7 @@ class TestImageSubmitStorageRetry:
         def mock_save_file(*args, **kwargs):
             """
             Simulate a storage save that always fails with a non-transient error.
-            
+
             Increments the external `call_count[0]` counter on each invocation and raises
             FileNotFoundError to emulate a non-transient storage failure (no return).
             """
@@ -843,7 +843,7 @@ class TestImageSubmitStorageRetry:
         def override_get_plugin_manager():
             """
             Provide the mocked plugin registry to use as the application's plugin manager override.
-            
+
             Returns:
                 mock_registry: The mocked plugin registry instance to be injected as the plugin manager.
             """
@@ -852,7 +852,7 @@ class TestImageSubmitStorageRetry:
         def override_get_plugin_service():
             """
             Provide the mocked plugin service used for dependency injection in tests.
-            
+
             Returns:
                 The mocked plugin service instance (`mock_service`) supplied by the test fixture.
             """
@@ -861,7 +861,7 @@ class TestImageSubmitStorageRetry:
         def override_get_storage():
             """
             Provide the mock storage instance for dependency overrides in tests.
-            
+
             Returns:
                 mock_storage: The mock storage object used by tests, exposing the same public methods as the production storage implementation (e.g. `save_file`).
             """
@@ -918,9 +918,9 @@ class TestImageSubmitStorageRetry:
         def mock_save_file(*args, **kwargs):
             """
             Mock replacement for a storage `save_file` function that records invocation and simulates a transient network failure.
-            
+
             Increments `call_count[0]` to indicate an attempted save, then raises a `ConnectionError`.
-            
+
             Raises:
                 ConnectionError: Always raised to simulate a transient network error.
             """
@@ -933,7 +933,7 @@ class TestImageSubmitStorageRetry:
         def override_get_plugin_manager():
             """
             Provide the mocked plugin registry to use as the application's plugin manager override.
-            
+
             Returns:
                 mock_registry: The mocked plugin registry instance to be injected as the plugin manager.
             """
@@ -942,7 +942,7 @@ class TestImageSubmitStorageRetry:
         def override_get_plugin_service():
             """
             Provide the mocked plugin service used for dependency injection in tests.
-            
+
             Returns:
                 The mocked plugin service instance (`mock_service`) supplied by the test fixture.
             """
@@ -951,7 +951,7 @@ class TestImageSubmitStorageRetry:
         def override_get_storage():
             """
             Provide the mock storage instance for dependency overrides in tests.
-            
+
             Returns:
                 mock_storage: The mock storage object used by tests, exposing the same public methods as the production storage implementation (e.g. `save_file`).
             """

--- a/server/tests/api/routes/test_image_submit.py
+++ b/server/tests/api/routes/test_image_submit.py
@@ -760,3 +760,133 @@ class TestImageSubmitStorageRetry:
         assert "job_id" in data
         # Verify retry happened
         assert call_count[0] >= 2, "Expected at least 2 calls (1 fail + 1 success)"
+
+    def test_non_transient_error_propagates_without_retry(
+        self, mock_plugin, session: Session
+    ):
+        """Non-transient errors like FileNotFoundError should NOT retry (Issue #337).
+
+        Only transient errors (ConnectionError, TimeoutError) should be retried.
+        Non-transient errors should propagate immediately.
+        """
+        from app.api_routes.routes.image_submit import get_storage
+
+        plugin = MagicMock()
+        plugin.tools = {
+            "analyze": {
+                "handler": "analyze_handler",
+                "input_schema": {"properties": {"image_bytes": {"type": "string"}}},
+            }
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = plugin
+
+        mock_service = MagicMock()
+        mock_service.get_available_tools.return_value = ["analyze"]
+
+        # Mock storage to raise non-transient error
+        call_count = [0]
+
+        def mock_save_file(*args, **kwargs):
+            call_count[0] += 1
+            raise FileNotFoundError("Path not found")
+
+        mock_storage = MagicMock()
+        mock_storage.save_file.side_effect = mock_save_file
+
+        def override_get_plugin_manager():
+            return mock_registry
+
+        def override_get_plugin_service():
+            return mock_service
+
+        def override_get_storage():
+            return mock_storage
+
+        app.dependency_overrides[get_plugin_manager] = override_get_plugin_manager
+        app.dependency_overrides[get_plugin_service] = override_get_plugin_service
+        app.dependency_overrides[get_storage] = override_get_storage
+
+        # Use raise_server_exceptions=False to catch exceptions as 500 responses
+        client = TestClient(app, raise_server_exceptions=False)
+
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+        response = client.post(
+            "/v1/image/submit?plugin_id=ocr&tool=analyze",
+            files={"file": ("test.png", BytesIO(png_data), "image/png")},
+        )
+
+        app.dependency_overrides.clear()
+
+        # Should fail with 500 (internal error) after exception is caught
+        assert (
+            response.status_code == 500
+        ), f"Got status {response.status_code}: {response.text[:200] if response.text else 'empty'}"
+        # CRITICAL (Issue #337): Should NOT retry non-transient errors
+        assert (
+            call_count[0] == 1
+        ), f"Expected exactly 1 call (no retry), got {call_count[0]} calls"
+
+    def test_transient_error_retries_three_times_then_raises(
+        self, mock_plugin, session: Session
+    ):
+        """Transient errors should retry exactly 3 times before raising (Issue #337)."""
+        from app.api_routes.routes.image_submit import get_storage
+
+        plugin = MagicMock()
+        plugin.tools = {
+            "analyze": {
+                "handler": "analyze_handler",
+                "input_schema": {"properties": {"image_bytes": {"type": "string"}}},
+            }
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = plugin
+
+        mock_service = MagicMock()
+        mock_service.get_available_tools.return_value = ["analyze"]
+
+        # Mock storage to always fail with transient error
+        call_count = [0]
+
+        def mock_save_file(*args, **kwargs):
+            call_count[0] += 1
+            raise ConnectionError("Network error")
+
+        mock_storage = MagicMock()
+        mock_storage.save_file.side_effect = mock_save_file
+
+        def override_get_plugin_manager():
+            return mock_registry
+
+        def override_get_plugin_service():
+            return mock_service
+
+        def override_get_storage():
+            return mock_storage
+
+        app.dependency_overrides[get_plugin_manager] = override_get_plugin_manager
+        app.dependency_overrides[get_plugin_service] = override_get_plugin_service
+        app.dependency_overrides[get_storage] = override_get_storage
+
+        # Use raise_server_exceptions=False to catch exceptions as 500 responses
+        client = TestClient(app, raise_server_exceptions=False)
+
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+        response = client.post(
+            "/v1/image/submit?plugin_id=ocr&tool=analyze",
+            files={"file": ("test.png", BytesIO(png_data), "image/png")},
+        )
+
+        app.dependency_overrides.clear()
+
+        # Should fail with 500 after retries exhausted
+        assert response.status_code == 500, f"Got: {response.text}"
+        # CRITICAL (Issue #337): Should retry exactly 3 times
+        assert (
+            call_count[0] == 3
+        ), f"Expected exactly 3 retries, got {call_count[0]} calls"

--- a/server/tests/api/routes/test_image_submit.py
+++ b/server/tests/api/routes/test_image_submit.py
@@ -631,3 +631,132 @@ class TestImageSubmitCanonicalJson:
         for tool_entry in data["tools"]:
             assert "logical" in tool_entry
             assert "resolved" in tool_entry
+
+    def test_canonical_json_legacy_tool_path(self, mock_plugin, session: Session):
+        """Legacy tool= path returns canonical JSON (Issue #333).
+
+        The docstring promises canonical JSON for ALL code paths,
+        but legacy tool= callers only got {"job_id": "..."}.
+        """
+        plugin = MagicMock()
+        plugin.tools = {
+            "analyze": {
+                "handler": "analyze_handler",
+                "input_schema": {"properties": {"image_bytes": {"type": "string"}}},
+            }
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = plugin
+
+        mock_service = MagicMock()
+        mock_service.get_available_tools.return_value = ["analyze"]
+
+        def override_get_plugin_manager():
+            return mock_registry
+
+        def override_get_plugin_service():
+            return mock_service
+
+        app.dependency_overrides[get_plugin_manager] = override_get_plugin_manager
+        app.dependency_overrides[get_plugin_service] = override_get_plugin_service
+
+        client = TestClient(app)
+
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+        response = client.post(
+            "/v1/image/submit?plugin_id=ocr&tool=analyze",
+            files={"file": ("test.png", BytesIO(png_data), "image/png")},
+        )
+
+        app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Canonical JSON fields - ALL paths should return these
+        assert "job_id" in data
+        assert "plugin" in data
+        assert data["plugin"] == "ocr"
+        assert "tool" in data
+        assert data["tool"] == "analyze"
+        assert "status" in data
+        assert data["status"] == "queued"
+        assert "submitted_at" in data
+        # ISO 8601 format check
+        assert "T" in data["submitted_at"]
+        assert data["submitted_at"].endswith("Z")
+
+
+class TestImageSubmitStorageRetry:
+    """Tests for storage retry logic (Issue #332)."""
+
+    def test_storage_save_retries_on_transient_failure(
+        self, mock_plugin, session: Session
+    ):
+        """Storage save retries on transient errors (Issue #332).
+
+        If storage.save_file fails with a transient error, it should be
+        retried with exponential backoff before raising.
+        """
+        from app.api_routes.routes.image_submit import get_storage
+
+        plugin = MagicMock()
+        plugin.tools = {
+            "analyze": {
+                "handler": "analyze_handler",
+                "input_schema": {"properties": {"image_bytes": {"type": "string"}}},
+            }
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = plugin
+
+        mock_service = MagicMock()
+        mock_service.get_available_tools.return_value = ["analyze"]
+
+        # Mock storage to fail once, then succeed
+        call_count = [0]
+
+        def mock_save_file(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call: simulate transient S3 error
+                raise ConnectionError("Transient network error")
+            # Second call: succeed
+            return "image/input/test.png"
+
+        mock_storage = MagicMock()
+        mock_storage.save_file.side_effect = mock_save_file
+
+        def override_get_plugin_manager():
+            return mock_registry
+
+        def override_get_plugin_service():
+            return mock_service
+
+        def override_get_storage():
+            return mock_storage
+
+        app.dependency_overrides[get_plugin_manager] = override_get_plugin_manager
+        app.dependency_overrides[get_plugin_service] = override_get_plugin_service
+        app.dependency_overrides[get_storage] = override_get_storage
+
+        client = TestClient(app)
+
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+        response = client.post(
+            "/v1/image/submit?plugin_id=ocr&tool=analyze",
+            files={"file": ("test.png", BytesIO(png_data), "image/png")},
+        )
+
+        app.dependency_overrides.clear()
+
+        # Should succeed after retry
+        assert response.status_code == 200, f"Got: {response.text}"
+        data = response.json()
+        assert "job_id" in data
+        # Verify retry happened
+        assert call_count[0] >= 2, "Expected at least 2 calls (1 fail + 1 success)"

--- a/server/tests/api/routes/test_image_submit.py
+++ b/server/tests/api/routes/test_image_submit.py
@@ -633,10 +633,10 @@ class TestImageSubmitCanonicalJson:
             assert "resolved" in tool_entry
 
     def test_canonical_json_legacy_tool_path(self, mock_plugin, session: Session):
-        """Legacy tool= path returns canonical JSON (Issue #333).
-
-        The docstring promises canonical JSON for ALL code paths,
-        but legacy tool= callers only got {"job_id": "..."}.
+        """
+        Verify that the legacy tool= submission path returns the canonical JSON response including job_id, plugin, tool, status and submitted_at.
+        
+        Submits a PNG file using the legacy query parameters (plugin_id and tool) and asserts a 200 response, presence of the canonical fields, and that `submitted_at` is an ISO 8601 UTC timestamp ending with 'Z'.
         """
         plugin = MagicMock()
         plugin.tools = {
@@ -653,9 +653,21 @@ class TestImageSubmitCanonicalJson:
         mock_service.get_available_tools.return_value = ["analyze"]
 
         def override_get_plugin_manager():
+            """
+            Provide the mocked plugin registry to use as the application's plugin manager override.
+            
+            Returns:
+                mock_registry: The mocked plugin registry instance to be injected as the plugin manager.
+            """
             return mock_registry
 
         def override_get_plugin_service():
+            """
+            Provide the mocked plugin service used for dependency injection in tests.
+            
+            Returns:
+                The mocked plugin service instance (`mock_service`) supplied by the test fixture.
+            """
             return mock_service
 
         app.dependency_overrides[get_plugin_manager] = override_get_plugin_manager
@@ -720,6 +732,15 @@ class TestImageSubmitStorageRetry:
         call_count = [0]
 
         def mock_save_file(*args, **kwargs):
+            """
+            Simulate a storage save operation that fails once with a transient network error and then succeeds.
+            
+            Returns:
+                str: The saved file path ("image/input/test.png") on successful save.
+            
+            Raises:
+                ConnectionError: On the first invocation to simulate a transient network error.
+            """
             call_count[0] += 1
             if call_count[0] == 1:
                 # First call: simulate transient S3 error
@@ -731,12 +752,30 @@ class TestImageSubmitStorageRetry:
         mock_storage.save_file.side_effect = mock_save_file
 
         def override_get_plugin_manager():
+            """
+            Provide the mocked plugin registry to use as the application's plugin manager override.
+            
+            Returns:
+                mock_registry: The mocked plugin registry instance to be injected as the plugin manager.
+            """
             return mock_registry
 
         def override_get_plugin_service():
+            """
+            Provide the mocked plugin service used for dependency injection in tests.
+            
+            Returns:
+                The mocked plugin service instance (`mock_service`) supplied by the test fixture.
+            """
             return mock_service
 
         def override_get_storage():
+            """
+            Provide the mock storage instance for dependency overrides in tests.
+            
+            Returns:
+                mock_storage: The mock storage object used by tests, exposing the same public methods as the production storage implementation (e.g. `save_file`).
+            """
             return mock_storage
 
         app.dependency_overrides[get_plugin_manager] = override_get_plugin_manager
@@ -789,6 +828,12 @@ class TestImageSubmitStorageRetry:
         call_count = [0]
 
         def mock_save_file(*args, **kwargs):
+            """
+            Simulate a storage save that always fails with a non-transient error.
+            
+            Increments the external `call_count[0]` counter on each invocation and raises
+            FileNotFoundError to emulate a non-transient storage failure (no return).
+            """
             call_count[0] += 1
             raise FileNotFoundError("Path not found")
 
@@ -796,12 +841,30 @@ class TestImageSubmitStorageRetry:
         mock_storage.save_file.side_effect = mock_save_file
 
         def override_get_plugin_manager():
+            """
+            Provide the mocked plugin registry to use as the application's plugin manager override.
+            
+            Returns:
+                mock_registry: The mocked plugin registry instance to be injected as the plugin manager.
+            """
             return mock_registry
 
         def override_get_plugin_service():
+            """
+            Provide the mocked plugin service used for dependency injection in tests.
+            
+            Returns:
+                The mocked plugin service instance (`mock_service`) supplied by the test fixture.
+            """
             return mock_service
 
         def override_get_storage():
+            """
+            Provide the mock storage instance for dependency overrides in tests.
+            
+            Returns:
+                mock_storage: The mock storage object used by tests, exposing the same public methods as the production storage implementation (e.g. `save_file`).
+            """
             return mock_storage
 
         app.dependency_overrides[get_plugin_manager] = override_get_plugin_manager
@@ -853,6 +916,14 @@ class TestImageSubmitStorageRetry:
         call_count = [0]
 
         def mock_save_file(*args, **kwargs):
+            """
+            Mock replacement for a storage `save_file` function that records invocation and simulates a transient network failure.
+            
+            Increments `call_count[0]` to indicate an attempted save, then raises a `ConnectionError`.
+            
+            Raises:
+                ConnectionError: Always raised to simulate a transient network error.
+            """
             call_count[0] += 1
             raise ConnectionError("Network error")
 
@@ -860,12 +931,30 @@ class TestImageSubmitStorageRetry:
         mock_storage.save_file.side_effect = mock_save_file
 
         def override_get_plugin_manager():
+            """
+            Provide the mocked plugin registry to use as the application's plugin manager override.
+            
+            Returns:
+                mock_registry: The mocked plugin registry instance to be injected as the plugin manager.
+            """
             return mock_registry
 
         def override_get_plugin_service():
+            """
+            Provide the mocked plugin service used for dependency injection in tests.
+            
+            Returns:
+                The mocked plugin service instance (`mock_service`) supplied by the test fixture.
+            """
             return mock_service
 
         def override_get_storage():
+            """
+            Provide the mock storage instance for dependency overrides in tests.
+            
+            Returns:
+                mock_storage: The mock storage object used by tests, exposing the same public methods as the production storage implementation (e.g. `save_file`).
+            """
             return mock_storage
 
         app.dependency_overrides[get_plugin_manager] = override_get_plugin_manager

--- a/server/tests/api/routes/test_video_submit.py
+++ b/server/tests/api/routes/test_video_submit.py
@@ -558,16 +558,30 @@ class TestVideoSubmitCanonicalJson:
     def test_canonical_json_legacy_tool_path(
         self, session: Session, mock_plugin_registry, mock_plugin_service
     ):
-        """Legacy tool= path returns canonical JSON (Issue #333).
-
-        The docstring promises canonical JSON for ALL code paths,
-        but legacy tool= callers only got {"job_id": "..."}.
+        """
+        Verify the legacy `tool=` request path returns the canonical JSON response.
+        
+        Asserts the response includes the canonical fields: `job_id`, `plugin` (equals "yolo-tracker"),
+        `tool` (equals "video_player_tracking"), `status` (equals "queued"), and `submitted_at`
+        in ISO 8601 format ending with a trailing "Z".
         """
 
         def override_get_plugin_manager():
+            """
+            Supply the mock plugin registry used to override the plugin manager dependency in tests.
+            
+            Returns:
+                mock_plugin_registry: The mock plugin registry object provided by the test fixture.
+            """
             return mock_plugin_registry
 
         def override_get_plugin_service():
+            """
+            Provide the mock plugin service for dependency override in tests.
+            
+            Returns:
+                mock_plugin_service: The mock plugin service object used to replace the real service in test dependency injection.
+            """
             return mock_plugin_service
 
         app.dependency_overrides[get_plugin_manager] = override_get_plugin_manager

--- a/server/tests/api/routes/test_video_submit.py
+++ b/server/tests/api/routes/test_video_submit.py
@@ -554,3 +554,52 @@ class TestVideoSubmitCanonicalJson:
         assert data["tools"][1]["resolved"] == "video_ball_detection"
         assert "submitted_at" in data
         assert data["status"] == "queued"
+
+    def test_canonical_json_legacy_tool_path(
+        self, session: Session, mock_plugin_registry, mock_plugin_service
+    ):
+        """Legacy tool= path returns canonical JSON (Issue #333).
+
+        The docstring promises canonical JSON for ALL code paths,
+        but legacy tool= callers only got {"job_id": "..."}.
+        """
+
+        def override_get_plugin_manager():
+            return mock_plugin_registry
+
+        def override_get_plugin_service():
+            return mock_plugin_service
+
+        app.dependency_overrides[get_plugin_manager] = override_get_plugin_manager
+        app.dependency_overrides[get_plugin_service] = override_get_plugin_service
+
+        client = TestClient(app)
+
+        mp4_data = b"ftypmp42" + b"\x00" * 100
+
+        response = client.post(
+            "/v1/video/submit",
+            files={"file": ("test.mp4", BytesIO(mp4_data))},
+            params={
+                "plugin_id": "yolo-tracker",
+                "tool": "video_player_tracking",
+            },
+        )
+
+        app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Canonical JSON fields - ALL paths should return these
+        assert "job_id" in data
+        assert "plugin" in data
+        assert data["plugin"] == "yolo-tracker"
+        assert "tool" in data
+        assert data["tool"] == "video_player_tracking"
+        assert "status" in data
+        assert data["status"] == "queued"
+        assert "submitted_at" in data
+        # ISO 8601 format check
+        assert "T" in data["submitted_at"]
+        assert data["submitted_at"].endswith("Z")

--- a/server/tests/api/routes/test_video_submit.py
+++ b/server/tests/api/routes/test_video_submit.py
@@ -560,7 +560,7 @@ class TestVideoSubmitCanonicalJson:
     ):
         """
         Verify the legacy `tool=` request path returns the canonical JSON response.
-        
+
         Asserts the response includes the canonical fields: `job_id`, `plugin` (equals "yolo-tracker"),
         `tool` (equals "video_player_tracking"), `status` (equals "queued"), and `submitted_at`
         in ISO 8601 format ending with a trailing "Z".
@@ -569,7 +569,7 @@ class TestVideoSubmitCanonicalJson:
         def override_get_plugin_manager():
             """
             Supply the mock plugin registry used to override the plugin manager dependency in tests.
-            
+
             Returns:
                 mock_plugin_registry: The mock plugin registry object provided by the test fixture.
             """
@@ -578,7 +578,7 @@ class TestVideoSubmitCanonicalJson:
         def override_get_plugin_service():
             """
             Provide the mock plugin service for dependency override in tests.
-            
+
             Returns:
                 mock_plugin_service: The mock plugin service object used to replace the real service in test dependency injection.
             """

--- a/server/tests/video/test_multi_tool_video.py
+++ b/server/tests/video/test_multi_tool_video.py
@@ -292,7 +292,7 @@ class TestMultiToolStatusEndpoint:
         job.progress = 25  # First tool at 50% = 25% overall
         session.commit()
 
-        # Test the logic from jobs.py endpoint
+        # Test the logic from jobs.py endpoint (Issue #334: use boundary comparison)
         # Get tools from job_tools table (v0.15.1: replaced tool_list column)
         tools_list = [
             jt.tool_id
@@ -303,7 +303,11 @@ class TestMultiToolStatusEndpoint:
         ]
         tools_total = len(tools_list)
         tool_weight = 100 / tools_total
-        tools_completed = int(job.progress / tool_weight)
+        # Use boundary comparison (matches fixed implementation)
+        boundaries = [
+            int((index + 1) * tool_weight) for index in range(tools_total - 1)
+        ]
+        tools_completed = sum(1 for boundary in boundaries if job.progress >= boundary)
 
         assert tools_total == 2
         assert tools_completed == 0  # First tool still running
@@ -327,9 +331,69 @@ class TestMultiToolStatusEndpoint:
         ]
         tools_total = len(tools_list)
         tool_weight = 100 / tools_total
-        tools_completed = int(job.progress / tool_weight)
+        # Use boundary comparison (matches fixed implementation)
+        boundaries = [
+            int((index + 1) * tool_weight) for index in range(tools_total - 1)
+        ]
+        tools_completed = sum(1 for boundary in boundaries if job.progress >= boundary)
 
         assert tools_completed == 1  # One tool completed
+
+    def test_three_tool_progress_boundary_at_33(self, session: Session):
+        """Test 3-tool job at progress 33 correctly reports tool 1 started (Issue #334).
+
+        For 3-tool job:
+        - tool_weight = 100/3 = 33.333...
+        - progress 33 = int(33.333) = tool 1 just started
+        - tools_completed should be 1 (one tool done, second running)
+
+        The bug: int(33 / 33.333) = int(0.99) = 0 (WRONG - should be 1)
+        """
+        tools = ["tool_one", "tool_two", "tool_three"]
+        job = create_video_job(session, tools=tools)
+        job.status = JobStatus.running
+        job.progress = 33  # Tool 1 just started
+        session.commit()
+
+        # Call the actual endpoint logic (will fail until fixed)
+        import asyncio
+
+        from app.api_routes.routes.jobs import get_job
+
+        response = asyncio.run(get_job(job.job_id, session))
+
+        # At progress 33, tool 1 has started (33.333 is tool 1's start)
+        # So tools_completed = 1, current_tool = tool_two
+        assert response.tools_completed == 1
+        assert response.current_tool == "tool_two"
+
+    def test_three_tool_progress_boundary_at_66(self, session: Session):
+        """Test 3-tool job at progress 66 correctly reports tool 2 started (Issue #334).
+
+        For 3-tool job:
+        - tool_weight = 100/3 = 33.333...
+        - progress 66 = int(66.666) = tool 2 just started
+        - tools_completed should be 2 (two tools done, third running)
+
+        The bug: int(66 / 33.333) = int(1.98) = 1 (WRONG - should be 2)
+        """
+        tools = ["tool_one", "tool_two", "tool_three"]
+        job = create_video_job(session, tools=tools)
+        job.status = JobStatus.running
+        job.progress = 66  # Tool 2 just started
+        session.commit()
+
+        # Call the actual endpoint logic
+        import asyncio
+
+        from app.api_routes.routes.jobs import get_job
+
+        response = asyncio.run(get_job(job.job_id, session))
+
+        # At progress 66, tool 2 has started (66.666 is tool 2's start)
+        # So tools_completed = 2, current_tool = tool_three
+        assert response.tools_completed == 2
+        assert response.current_tool == "tool_three"
 
 
 # Fixtures for mock services

--- a/web-ui/src/App.multitool.test.tsx
+++ b/web-ui/src/App.multitool.test.tsx
@@ -26,6 +26,9 @@ vi.mock("./components/PluginSelector", () => ({
       <button data-testid="select-yolo" onClick={() => props.onPluginChange("yolo-tracker")}>
         Select YOLO
       </button>
+      <button data-testid="select-nocap" onClick={() => props.onPluginChange("no-cap-plugin")}>
+        Select NoCap
+      </button>
     </div>
   ),
 }));
@@ -64,6 +67,17 @@ vi.mock("./api/client", () => ({
               inputs: {},
               outputs: { result: { type: "object" } },
             },
+          },
+        });
+      }
+      if (pluginId === "no-cap-plugin") {
+        // Manifest WITHOUT capabilities - only tool IDs
+        return Promise.resolve({
+          id: "no-cap-plugin",
+          name: "No Cap Plugin",
+          tools: {
+            toolA: { input_types: ["image"], inputs: {}, outputs: {} },
+            toolB: { input_types: ["image"], inputs: {}, outputs: {} },
           },
         });
       }
@@ -234,5 +248,122 @@ describe("Multitool Selection - REAL tests", () => {
       expect(toolButtons[0].getAttribute("aria-pressed")).toBe("true");
       expect(toolButtons[1].getAttribute("aria-pressed")).toBe("true");
     }, { timeout: 3000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Discussion #335: isUsingLogicalIds derivation tests
+// These tests verify that useLogicalId is derived from manifest, not hardcoded
+// ---------------------------------------------------------------------------
+describe("Discussion #335: isUsingLogicalIds derivation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test A: Manifest WITH capabilities → useLogicalId=true
+  // -------------------------------------------------------------------------
+  it("passes useLogicalId=true when manifest HAS capabilities", { timeout: 15000 }, async () => {
+    const { apiClient } = await import("./api/client");
+
+    render(<App />);
+
+    // Select plugin (yolo-tracker has capabilities in mock)
+    await userEvent.click(screen.getByTestId("select-yolo"));
+
+    // Wait for manifest load
+    await waitFor(() => {
+      expect(apiClient.getPluginManifest).toHaveBeenCalled();
+    }, { timeout: 5000 });
+
+    // Switch to Upload view
+    const navButtons = screen.getAllByRole("button");
+    const uploadNavBtn = navButtons.find(b =>
+      b.textContent?.toLowerCase().trim() === "upload"
+    );
+    if (uploadNavBtn) {
+      await userEvent.click(uploadNavBtn);
+    }
+
+    // Select capability buttons
+    const buttons = screen.getAllByRole("button");
+    const capButtons = buttons.filter(b =>
+      (b.textContent || "").toLowerCase().includes("detection")
+    );
+
+    if (capButtons.length >= 2) {
+      await userEvent.click(capButtons[0]);
+      await userEvent.click(capButtons[1]);
+    } else if (capButtons.length === 1) {
+      await userEvent.click(capButtons[0]);
+    }
+
+    // Upload image
+    const fileInput = await screen.findByTestId("image-upload");
+    const file = new File(["x"], "x.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await waitFor(() => {
+      expect(apiClient.submitImage).toHaveBeenCalled();
+    }, { timeout: 5000 });
+
+    const call = apiClient.submitImage.mock.calls[0];
+    const useLogicalId = call[4];
+    expect(useLogicalId).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test B: Manifest WITHOUT capabilities → useLogicalId=false
+  // THIS TEST SHOULD FAIL until we fix the hardcoded useLogicalId=true
+  // -------------------------------------------------------------------------
+  it("passes useLogicalId=false when manifest has NO capabilities", { timeout: 15000 }, async () => {
+    const { apiClient } = await import("./api/client");
+
+    render(<App />);
+
+    // Select no-cap-plugin (manifest has NO capabilities, only tool IDs)
+    await userEvent.click(screen.getByTestId("select-nocap"));
+
+    // Wait for manifest load
+    await waitFor(() => {
+      expect(apiClient.getPluginManifest).toHaveBeenCalledWith("no-cap-plugin");
+    }, { timeout: 5000 });
+
+    // Switch to Upload view
+    const navButtons = screen.getAllByRole("button");
+    const uploadNavBtn = navButtons.find(b =>
+      b.textContent?.toLowerCase().trim() === "upload"
+    );
+    if (uploadNavBtn) {
+      await userEvent.click(uploadNavBtn);
+    }
+
+    // Get tool buttons (toolA, toolB - no capabilities, just IDs)
+    const buttons = screen.getAllByRole("button");
+    const toolButtons = buttons.filter(b =>
+      (b.textContent || "").toLowerCase().includes("tool")
+    );
+
+    if (toolButtons.length >= 1) {
+      await userEvent.click(toolButtons[0]);
+    }
+
+    // Upload image
+    const fileInput = await screen.findByTestId("image-upload");
+    const file = new File(["x"], "x.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await waitFor(() => {
+      expect(apiClient.submitImage).toHaveBeenCalled();
+    }, { timeout: 5000 });
+
+    const call = apiClient.submitImage.mock.calls[0];
+    const useLogicalId = call[4];
+    
+    // Discussion #335: When manifest has NO capabilities, useLogicalId should be FALSE
+    // THIS WILL FAIL with current code because useLogicalId is hardcoded to true
+    expect(useLogicalId).toBe(false);
   });
 });

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -30,6 +30,13 @@ const WS_BACKEND_URL =
 
 type ViewMode = "stream" | "upload" | "jobs" | "video-upload" | "video-stream";
 
+/**
+ * Root application component that manages UI state, plugin manifests, WebSocket streaming, uploads, job polling and video processing views.
+ *
+ * Renders the main layout including plugin and tool selectors, stream/upload/job/video views, and results pane while coordinating network interactions (manifest loading, WebSocket streaming, image/video submission and job polling) and related UI state.
+ *
+ * @returns The root JSX element for the application
+ */
 function App() {
   // -------------------------------------------------------------------------
   // State

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -58,9 +58,10 @@ function App() {
   // Compute tool list from manifest
   // FIX: Return capabilities (logical tool names), not tool IDs
   // v0.15.0: Extract capabilities from tool.capabilities for multi-tool support
+  // Discussion #335: Track whether we're using logical IDs (capabilities)
   // -------------------------------------------------------------------------
-  const toolList = useMemo(() => {
-    if (!manifest) return [];
+  const { toolList, isUsingLogicalIds } = useMemo(() => {
+    if (!manifest) return { toolList: [], isUsingLogicalIds: false };
 
     // Collect all unique capabilities from all tools
     const allCapabilities = new Set<string>();
@@ -76,10 +77,13 @@ function App() {
         }
       }
       if (allCapabilities.size > 0) {
-        return Array.from(allCapabilities);
+        return { toolList: Array.from(allCapabilities), isUsingLogicalIds: true };
       }
       // Fallback: no capabilities, return tool IDs
-      return manifest.tools.map((tool: { id: string }) => tool.id);
+      return {
+        toolList: manifest.tools.map((tool: { id: string }) => tool.id),
+        isUsingLogicalIds: false,
+      };
     }
 
     // Legacy format: tools is an object where keys are tool IDs
@@ -94,11 +98,11 @@ function App() {
     }
 
     if (allCapabilities.size > 0) {
-      return Array.from(allCapabilities);
+      return { toolList: Array.from(allCapabilities), isUsingLogicalIds: true };
     }
 
     // Fallback: no capabilities found, return tool IDs
-    return Object.keys(toolsObj);
+    return { toolList: Object.keys(toolsObj), isUsingLogicalIds: false };
   }, [manifest]);
 
   // -------------------------------------------------------------------------
@@ -359,13 +363,13 @@ function App() {
       setIsUploading(true);
       try {
         // v0.9.4: Pass all selected tools (not just first) for multi-tool support
-        // v0.15.0: Pass useLogicalId=true so backend resolves capabilities to tool IDs
+        // Discussion #335: useLogicalId derived from manifest capabilities
         const response = await apiClient.submitImage(
           file,
           selectedPlugin,
           selectedTools,
           undefined,  // onProgress callback (not used)
-          true  // useLogicalId: send logical_tool_id instead of tool
+          isUsingLogicalIds  // Derived from resolver mode
         );
         const job = await apiClient.pollJob(response.job_id);
         setSelectedJob(job);
@@ -375,7 +379,7 @@ function App() {
         setIsUploading(false);
       }
     },
-    [selectedPlugin, selectedTools, streamEnabled]
+    [selectedPlugin, selectedTools, streamEnabled, isUsingLogicalIds]
   );
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes 4 issues identified by CodeRabbit AI and Discussion #335:

### Issue #332: Storage retry/backoff
- Added tenacity retry wrapper for `storage.save_file()` in image_submit.py
- Retries up to 3 times with exponential backoff (2-10s)

### Issue #333: Legacy response contract violation
- Fixed legacy `tool=` path to return canonical JSON with `plugin`, `status`, `submitted_at`
- Applied fix to both image_submit.py and video_submit.py

### Issue #334: Progress calculation truncation bug
- Fixed boundary comparison for multi-tool progress tracking
- Changed from `int(progress / tool_weight)` to boundary-based calculation

### Discussion #335: useLogicalId hardcoded
- Derived `isUsingLogicalIds` from manifest capabilities
- `true` when tools have capabilities (logical IDs)
- `false` when falling back to tool IDs (no capabilities)

## TEST-CHANGE Justification

### server/tests/api/routes/test_image_submit.py
Added tests for:
- Issue #332: Storage retry on transient failure
- Issue #333: Legacy tool= path returns canonical JSON

Required to verify retry logic works correctly and API contract is maintained.

### server/tests/api/routes/test_video_submit.py
Added test for:
- Issue #333: Legacy tool= path returns canonical JSON

Required to verify video endpoint returns proper canonical JSON.

### server/tests/video/test_multi_tool_video.py
Added tests for:
- Issue #334: 3-tool progress boundaries at 33% and 66%

Required to verify progress calculation fix handles boundary values correctly.

### web-ui/src/App.multitool.test.tsx
Added tests for:
- Discussion #335: useLogicalId derivation from manifest capabilities

Required to verify that `isUsingLogicalIds` is correctly derived:
- `true` when manifest has capabilities
- `false` when manifest has no capabilities (fallback to tool IDs)

All tests follow TDD methodology: written first to fail, then implementation fixed.

## Related

- Closes #332
- Closes #333
- Closes #334
- Addresses Discussion #335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonical JSON responses for image and video submissions (job_id, plugin, status, submitted_at) with conditional tool/tools fields
  * UI: propagate derived logical-ID mode for tool selection into submission flow
  * Stronger submission validation (mutual exclusivity of tool vs logical IDs; MP4/file validation) and clearer error responses

* **Bug Fixes**
  * Retry logic for image storage uploads to handle transient failures
  * Boundary-based progress calculation for multi-tool video jobs (improves current_tool determination)

* **Tests**
  * Expanded tests for canonical responses, storage retry behaviour, multi-tool progress boundaries and UI selection flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->