### PR TITLE
ci: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -47,7 +47,7 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Clone forgesyte-plugins (for integration tests)
         run: |
@@ -55,7 +55,7 @@ jobs:
           git clone --depth 1 https://github.com/rogermt/forgesyte-plugins.git forgesyte-plugins
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -93,7 +93,7 @@ jobs:
     needs: lint
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -129,10 +129,10 @@ jobs:
     needs: [test, web-ui]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -163,7 +163,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fetch main
         run: git fetch origin main
@@ -232,7 +232,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Detect skipped tests
         id: skipped
@@ -291,10 +291,10 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/execution-ci.yml
+++ b/.github/workflows/execution-ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Clone forgesyte-plugins (for integration tests)
         run: |
@@ -19,7 +19,7 @@ jobs:
           git clone --depth 1 https://github.com/rogermt/forgesyte-plugins.git forgesyte-plugins
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/governance-ci.yml
+++ b/.github/workflows/governance-ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/vocabulary_validation.yml
+++ b/.github/workflows/vocabulary_validation.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       
@@ -37,10 +37,10 @@ jobs:
     needs: scan
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       
@@ -62,10 +62,10 @@ jobs:
     needs: tests
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       


### PR DESCRIPTION
## Summary

Updates GitHub Actions to Node.js 24 compatible versions to address deprecation warning.

**Node.js 20 actions are deprecated** and will be forced to run on Node.js 24 starting June 2nd, 2026.

## Changes

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | v6 |
| actions/setup-python | v4/v5 | v6 |

## Files Modified

- `.github/workflows/ci.yml` (11 replacements)
- `.github/workflows/vocabulary_validation.yml` (6 replacements)
- `.github/workflows/execution-ci.yml` (2 replacements)
- `.github/workflows/governance-ci.yml` (2 replacements)

## Reference

- [GitHub Actions Node.js 20 Deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- [actions/checkout v6 Release](https://github.com/actions/checkout/releases/tag/v6.0.0)
- [actions/setup-python v6 Release](https://github.com/actions/setup-python/releases/tag/v6.0.0)

## Minimum Runner Version

v2.327.1 or later required for these action versions.

TEST CHANGE JUSTIFICATION
no tests were modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflow tooling to latest versions, improving build and deployment infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->