### PR TITLE
ci: update pre-commit/action to v3.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
       - name: Run mypy type checking
         run: |


### PR DESCRIPTION
Update pre-commit/action from v3.0.0 to v3.0.1 for Node.js 24 compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit GitHub Action to v3.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->