### PR TITLE
v0.15.7: Fix logging suppression and video upload blocking

### DIFF
--- a/server/app/api_routes/routes/video_submit.py
+++ b/server/app/api_routes/routes/video_submit.py
@@ -12,12 +12,21 @@ v0.10.1: Split video upload and job submission for deterministic tool-locking.
 - POST /v1/video/submit: Accepts JSON body {plugin_id, video_path, lockedTools}
 """
 
+import asyncio
+import logging
+import traceback
 from datetime import timezone
 from io import BytesIO
 from typing import List
 from uuid import uuid4
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, UploadFile
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from app.core.database import SessionLocal
 from app.models.job import Job, JobStatus
@@ -28,8 +37,17 @@ from app.services.storage.factory import get_storage_service
 from app.services.tool_router import resolve_tools
 from app.settings import settings
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
-storage = get_storage_service(settings)
+
+
+def get_storage():
+    """Get storage service via lazy initialization.
+
+    This avoids import-time S3 connection attempts and allows
+    dependency injection for testing.
+    """
+    return get_storage_service(settings)
 
 
 def get_plugin_manager():
@@ -99,8 +117,26 @@ async def upload_video(
     video_id = uuid4()
     video_path = f"video/input/{video_id}.mp4"
 
-    # Save file to storage
-    storage.save_file(src=BytesIO(contents), dest_path=video_path)
+    # Save file to storage with async retry logic
+    storage = get_storage()
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        reraise=True,
+    )
+    async def save_file_with_retry():
+        await asyncio.to_thread(
+            storage.save_file, src=BytesIO(contents), dest_path=video_path
+        )
+
+    try:
+        await save_file_with_retry()
+        logger.info(f"Video uploaded to {video_path}")
+    except Exception as e:
+        logger.error(f"Storage save failed after retries: {e}")
+        raise
 
     return {"video_path": video_path}
 
@@ -186,6 +222,7 @@ async def submit_video_job(
             )
 
     # Validate video file exists
+    storage = get_storage()
     if not storage.file_exists(video_path):
         raise HTTPException(
             status_code=400,
@@ -362,8 +399,28 @@ async def submit_video(
     job_id = uuid4()
     input_path = f"video/input/{job_id}.mp4"
 
-    # Save file to storage
-    storage.save_file(src=BytesIO(contents), dest_path=input_path)
+    # Save file to storage with async retry logic
+    storage = get_storage()
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        reraise=True,
+    )
+    async def save_file_with_retry():
+        await asyncio.to_thread(
+            storage.save_file, src=BytesIO(contents), dest_path=input_path
+        )
+
+    try:
+        await save_file_with_retry()
+        logger.info(f"Video saved to {input_path}")
+    except Exception as e:
+        logger.error(
+            f"Storage save failed after retries: {e}\n{traceback.format_exc()}"
+        )
+        raise
 
     # Create database record
     db = SessionLocal()

--- a/server/tests/api/routes/test_video_split_endpoints.py
+++ b/server/tests/api/routes/test_video_split_endpoints.py
@@ -202,9 +202,11 @@ class TestVideoJobEndpoint:
 
         client = TestClient(app)
 
-        # Mock storage.file_exists to return True
+        # Mock get_storage to return a mock with file_exists
+        mock_storage = MagicMock()
+        mock_storage.file_exists.return_value = True
         with patch(
-            "app.api_routes.routes.video_submit.storage.file_exists", return_value=True
+            "app.api_routes.routes.video_submit.get_storage", return_value=mock_storage
         ):
             response = client.post(
                 "/v1/video/job",


### PR DESCRIPTION
## Summary

Two critical fixes:
1. **Logging suppression** - Alembic migrations were overriding root logger level
2. **Video upload blocking** - Synchronous storage calls freezing the UI

## Fixes

### 1. Logging Suppression (commits 996c1ad, 5891fdc, 5315cac, 3c0ebef)

**Root Cause:** `alembic.ini` contained logging configuration that set root logger to WARNING, overriding DEBUG level set by `setup_logging()`.

**Changes:**
- Remove Alembic logging config sections from `server/alembic.ini`
- Restructure `main.py` - imports BEFORE `setup_logging()`
- Fix format string to use valid LogRecord attributes
- Use `FORGESYTE_LOG_LEVEL` and `FORGESYTE_LOG_FILE` from env vars
- Remove `debug_file()` workaround from `image_submit.py`

### 2. Video Upload Blocking (commit 6f79d34)

**Root Cause:** `video_submit.py` used synchronous `storage.save_file()` calls, blocking the FastAPI event loop during large video uploads.

**Changes:**
- Wrap `storage.save_file()` with `asyncio.to_thread()`
- Add retry logic (3 retries, exponential backoff)
- Change to lazy `get_storage()` pattern
- Add logging for upload success/failure

## TEST-CHANGE JUSTIFICATION

**File:** `server/tests/api/routes/test_video_split_endpoints.py`

**Reason:** The test was mocking `video_submit.storage.file_exists` which no longer exists after refactoring to use the `get_storage()` function pattern. Updated the mock to patch `get_storage` instead, returning a mock object with the required `file_exists` method.

**Commit:** 5662839

## Testing

- Verified logging captures all startup logs (numba, plugin discovery, service init)
- Verified video uploads no longer block the UI
- All tests pass including `test_video_job_accepts_json_body`